### PR TITLE
feat: Add rust-snappy as an alternative compression backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ keywords = ["voxel"]
 all-features = true
 
 [features]
-default = ["mesh", "partition", "procgen", "search"]
+default = ["mesh", "partition", "procgen", "search", "compress-lz4"]
 
+compress-lz4 = ["building_blocks_storage/compress-lz4"]
+compress-snappy = ["building_blocks_storage/compress-snappy"]
 image = ["building_blocks_image"]
 mesh = ["building_blocks_mesh"]
 mint = ["building_blocks_core/mint"]

--- a/crates/building_blocks_storage/Cargo.toml
+++ b/crates/building_blocks_storage/Cargo.toml
@@ -9,18 +9,24 @@ keywords = ["voxel"]
 
 description = "Efficient storage for maps on sparse or dense, 2D and 3D integer lattices."
 
+[features]
+compress-lz4 = ["lz4", "compressible-map/bincode_lz4"]
+compress-snappy = ["snap", "compressible-map/bincode_snappy"]
+
 [dependencies]
 either = "1.6"
 fnv = "1.0"
 futures = "0.3"
 itertools = "0.9"
-lz4 = "1.23"
+lz4 = { version = "1.23", optional = true }
 num = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+snap = { version = "1.0.3", optional = true }
 
 building_blocks_core = { path = "../building_blocks_core", version = "0.2" }
 
-compressible-map = { version = "^0.1.5", features = ["bincode_lz4"] }
+# FIXME: point this at the new release once compressible-map gets a new release
+compressible-map = { git = "https://github.com/bonsairobo/compressible-map", rev = "c7d80e1" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/crates/building_blocks_storage/src/access.rs
+++ b/crates/building_blocks_storage/src/access.rs
@@ -46,8 +46,13 @@
 //! let chunk_shape = PointN([16; 3]);
 //! let ambient_value = 0;
 //! let default_chunk_metadata = ();
+//! # #[cfg(feature = "compress-lz4")]
 //! let mut other_map = ChunkMap3::new(
 //!     chunk_shape, ambient_value, default_chunk_metadata, FastLz4 { level: 10 }
+//! );
+//! # #[cfg(feature = "compress-snappy")]
+//! let mut other_map = ChunkMap3::new(
+//!     chunk_shape, ambient_value, default_chunk_metadata, FastSnappy
 //! );
 //! copy_extent(&subextent, &map, &mut other_map);
 //! let local_cache = LocalChunkCache3::new();

--- a/crates/building_blocks_storage/src/array/lz4.rs
+++ b/crates/building_blocks_storage/src/array/lz4.rs
@@ -1,0 +1,88 @@
+use super::ArrayN;
+
+use building_blocks_core::prelude::*;
+
+use compressible_map::{Compressible, Decompressible};
+
+/// A compression algorithm that decompresses quickly, but only on the same platform where it was
+/// compressed.
+#[derive(Clone, Copy, Debug)]
+pub struct FastLz4 {
+    pub level: u32,
+}
+
+/// A compressed `ArrayN` that decompresses quickly, but only on the same platform where it
+/// was compressed.
+#[derive(Clone)]
+pub struct FastLz4CompressedArrayN<N, T> {
+    pub compressed_bytes: Vec<u8>,
+    pub extent: ExtentN<N>,
+    marker: std::marker::PhantomData<T>,
+}
+
+impl<N, T> FastLz4CompressedArrayN<N, T> {
+    pub fn extent(&self) -> &ExtentN<N> {
+        &self.extent
+    }
+}
+
+impl<N, T> Decompressible<FastLz4> for FastLz4CompressedArrayN<N, T>
+where
+    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
+    ExtentN<N>: IntegerExtent<N>,
+{
+    type Decompressed = ArrayN<N, T>;
+
+    fn decompress(&self) -> Self::Decompressed {
+        let num_points = self.extent.num_points();
+
+        let mut decoder = lz4::Decoder::new(self.compressed_bytes.as_slice()).unwrap();
+        // Allocate the vector with element type T so the alignment is correct.
+        let mut decompressed_values: Vec<T> = Vec::with_capacity(num_points);
+        unsafe { decompressed_values.set_len(num_points) };
+        let mut decompressed_slice = unsafe {
+            std::slice::from_raw_parts_mut(
+                decompressed_values.as_mut_ptr() as *mut u8,
+                num_points * core::mem::size_of::<T>(),
+            )
+        };
+        std::io::copy(&mut decoder, &mut decompressed_slice).unwrap();
+
+        ArrayN::new(self.extent, decompressed_values)
+    }
+}
+
+impl<N, T> Compressible<FastLz4> for ArrayN<N, T>
+where
+    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
+    ExtentN<N>: IntegerExtent<N>,
+{
+    type Compressed = FastLz4CompressedArrayN<N, T>;
+
+    // Compress the map in-memory using the LZ4 algorithm.
+    //
+    // WARNING: For performance, this reinterprets the inner vector as a byte slice without
+    // accounting for endianness. This is not compatible across platforms.
+    fn compress(&self, params: FastLz4) -> FastLz4CompressedArrayN<N, T> {
+        let mut compressed_bytes = Vec::new();
+        let values_slice: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                self.values.as_ptr() as *const u8,
+                self.values.len() * core::mem::size_of::<T>(),
+            )
+        };
+        let mut encoder = lz4::EncoderBuilder::new()
+            .level(params.level)
+            .build(&mut compressed_bytes)
+            .unwrap();
+
+        std::io::copy(&mut std::io::Cursor::new(values_slice), &mut encoder).unwrap();
+        let (_output, _result) = encoder.finish();
+
+        FastLz4CompressedArrayN {
+            extent: self.extent,
+            compressed_bytes,
+            marker: Default::default(),
+        }
+    }
+}

--- a/crates/building_blocks_storage/src/array/mod.rs
+++ b/crates/building_blocks_storage/src/array/mod.rs
@@ -77,7 +77,6 @@ use crate::{
 
 use building_blocks_core::prelude::*;
 
-use compressible_map::{Compressible, Decompressible};
 use core::iter::{once, Once};
 use core::mem::MaybeUninit;
 use core::ops::{Add, AddAssign, Deref, Mul, Sub, SubAssign};
@@ -710,88 +709,14 @@ where
 // ╚██████╗╚██████╔╝██║ ╚═╝ ██║██║     ██║  ██║███████╗███████║███████║██║╚██████╔╝██║ ╚████║
 //  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 
-/// A compression algorithm that decompresses quickly, but only on the same platform where it was
-/// compressed.
-#[derive(Clone, Copy, Debug)]
-pub struct FastLz4 {
-    pub level: u32,
-}
-
-/// A compressed `ArrayN` that decompresses quickly, but only on the same platform where it
-/// was compressed.
-#[derive(Clone)]
-pub struct FastLz4CompressedArrayN<N, T> {
-    pub compressed_bytes: Vec<u8>,
-    pub extent: ExtentN<N>,
-    marker: std::marker::PhantomData<T>,
-}
-
-impl<N, T> FastLz4CompressedArrayN<N, T> {
-    pub fn extent(&self) -> &ExtentN<N> {
-        &self.extent
-    }
-}
-
-impl<N, T> Decompressible<FastLz4> for FastLz4CompressedArrayN<N, T>
-where
-    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
-    ExtentN<N>: IntegerExtent<N>,
-{
-    type Decompressed = ArrayN<N, T>;
-
-    fn decompress(&self) -> Self::Decompressed {
-        let num_points = self.extent.num_points();
-
-        let mut decoder = lz4::Decoder::new(self.compressed_bytes.as_slice()).unwrap();
-        // Allocate the vector with element type T so the alignment is correct.
-        let mut decompressed_values: Vec<T> = Vec::with_capacity(num_points);
-        unsafe { decompressed_values.set_len(num_points) };
-        let mut decompressed_slice = unsafe {
-            std::slice::from_raw_parts_mut(
-                decompressed_values.as_mut_ptr() as *mut u8,
-                num_points * core::mem::size_of::<T>(),
-            )
-        };
-        std::io::copy(&mut decoder, &mut decompressed_slice).unwrap();
-
-        ArrayN::new(self.extent, decompressed_values)
-    }
-}
-
-impl<N, T> Compressible<FastLz4> for ArrayN<N, T>
-where
-    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
-    ExtentN<N>: IntegerExtent<N>,
-{
-    type Compressed = FastLz4CompressedArrayN<N, T>;
-
-    // Compress the map in-memory using the LZ4 algorithm.
-    //
-    // WARNING: For performance, this reinterprets the inner vector as a byte slice without
-    // accounting for endianness. This is not compatible across platforms.
-    fn compress(&self, params: FastLz4) -> FastLz4CompressedArrayN<N, T> {
-        let mut compressed_bytes = Vec::new();
-        let values_slice: &[u8] = unsafe {
-            std::slice::from_raw_parts(
-                self.values.as_ptr() as *const u8,
-                self.values.len() * core::mem::size_of::<T>(),
-            )
-        };
-        let mut encoder = lz4::EncoderBuilder::new()
-            .level(params.level)
-            .build(&mut compressed_bytes)
-            .unwrap();
-
-        std::io::copy(&mut std::io::Cursor::new(values_slice), &mut encoder).unwrap();
-        let (_output, _result) = encoder.finish();
-
-        FastLz4CompressedArrayN {
-            extent: self.extent,
-            compressed_bytes,
-            marker: Default::default(),
-        }
-    }
-}
+#[cfg(feature = "compress-lz4")]
+mod lz4;
+#[cfg(feature = "compress-lz4")]
+pub use self::lz4::{FastLz4, FastLz4CompressedArrayN};
+#[cfg(feature = "compress-snappy")]
+mod snappy;
+#[cfg(feature = "compress-snappy")]
+pub use snappy::{FastSnappy, FastSnappyCompressedArrayN};
 
 // ████████╗███████╗███████╗████████╗
 // ╚══██╔══╝██╔════╝██╔════╝╚══██╔══╝

--- a/crates/building_blocks_storage/src/array/snappy.rs
+++ b/crates/building_blocks_storage/src/array/snappy.rs
@@ -1,0 +1,92 @@
+use super::ArrayN;
+
+use building_blocks_core::prelude::*;
+
+use compressible_map::{Compressible, Decompressible};
+
+//  ██████╗ ██████╗ ███╗   ███╗██████╗ ██████╗ ███████╗███████╗███████╗██╗ ██████╗ ███╗   ██╗
+// ██╔════╝██╔═══██╗████╗ ████║██╔══██╗██╔══██╗██╔════╝██╔════╝██╔════╝██║██╔═══██╗████╗  ██║
+// ██║     ██║   ██║██╔████╔██║██████╔╝██████╔╝█████╗  ███████╗███████╗██║██║   ██║██╔██╗ ██║
+// ██║     ██║   ██║██║╚██╔╝██║██╔═══╝ ██╔══██╗██╔══╝  ╚════██║╚════██║██║██║   ██║██║╚██╗██║
+// ╚██████╗╚██████╔╝██║ ╚═╝ ██║██║     ██║  ██║███████╗███████║███████║██║╚██████╔╝██║ ╚████║
+//  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+
+/// A compression algorithm that decompresses faster than similar algorithms (LZO, LZF, QuickLZ,
+/// etc.) but is primarily optimized for 64-bit x86-compatible processors.
+///
+/// Unlike the LZ4 backend, `FastSnappy` uses a compression algorithm implemented entirely in
+/// rust, which means it can be compiled for targets like `wasm32-unknown-unknown`.
+#[derive(Clone, Copy, Debug)]
+pub struct FastSnappy;
+
+/// A compressed `ArrayN` that decompresses faster than similar algorithms (LZO, LZF, QuickLZ,
+/// etc.) but is primarily optimized for 64-bit x86-compatible processors.
+#[derive(Clone)]
+pub struct FastSnappyCompressedArrayN<N, T> {
+    pub compressed_bytes: Vec<u8>,
+    pub extent: ExtentN<N>,
+    marker: std::marker::PhantomData<T>,
+}
+
+impl<N, T> FastSnappyCompressedArrayN<N, T> {
+    pub fn extent(&self) -> &ExtentN<N> {
+        &self.extent
+    }
+}
+
+impl<N, T> Decompressible<FastSnappy> for FastSnappyCompressedArrayN<N, T>
+where
+    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
+    ExtentN<N>: IntegerExtent<N>,
+{
+    type Decompressed = ArrayN<N, T>;
+
+    fn decompress(&self) -> Self::Decompressed {
+        let num_points = self.extent.num_points();
+
+        let mut decoder = snap::read::FrameDecoder::new(self.compressed_bytes.as_slice());
+        // Allocate the vector with element type T so the alignment is correct.
+        let mut decompressed_values: Vec<T> = Vec::with_capacity(num_points);
+        unsafe { decompressed_values.set_len(num_points) };
+        let mut decompressed_slice = unsafe {
+            std::slice::from_raw_parts_mut(
+                decompressed_values.as_mut_ptr() as *mut u8,
+                num_points * core::mem::size_of::<T>(),
+            )
+        };
+        std::io::copy(&mut decoder, &mut decompressed_slice).unwrap();
+
+        ArrayN::new(self.extent, decompressed_values)
+    }
+}
+
+impl<N, T> Compressible<FastSnappy> for ArrayN<N, T>
+where
+    T: Copy, // Copy is important so we don't serialize a vector of non-POD type
+    ExtentN<N>: IntegerExtent<N>,
+{
+    type Compressed = FastSnappyCompressedArrayN<N, T>;
+
+    // Compress the map in-memory using the snappy algorithm.
+    //
+    // WARNING: For performance, this reinterprets the inner vector as a byte slice without
+    // accounting for endianness. This is not compatible across platforms.
+    fn compress(&self, _params: FastSnappy) -> FastSnappyCompressedArrayN<N, T> {
+        let values_slice: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                self.values.as_ptr() as *const u8,
+                self.values.len() * core::mem::size_of::<T>(),
+            )
+        };
+        let mut encoder = snap::write::FrameEncoder::new(Vec::new());
+
+        std::io::copy(&mut std::io::Cursor::new(values_slice), &mut encoder).unwrap();
+        let compressed_bytes = encoder.into_inner().expect("failed to get the underlying stream");
+
+        FastSnappyCompressedArrayN {
+            extent: self.extent,
+            compressed_bytes,
+            marker: Default::default(),
+        }
+    }
+}

--- a/crates/building_blocks_storage/src/lib.rs
+++ b/crates/building_blocks_storage/src/lib.rs
@@ -18,7 +18,11 @@ pub mod func;
 pub mod transform_map;
 
 pub use access::{copy_extent, ForEach, ForEachMut, Get, GetMut, ReadExtent, WriteExtent};
-pub use array::{Array, ArrayN, FastLz4, Local, Stride};
+#[cfg(feature = "compress-lz4")]
+pub use array::FastLz4;
+#[cfg(feature = "compress-snappy")]
+pub use array::FastSnappy;
+pub use array::{Array, ArrayN, Local, Stride};
 pub use array2::Array2;
 pub use array3::Array3;
 pub use chunk_map::{
@@ -36,10 +40,14 @@ pub trait IsEmpty {
 pub mod prelude {
     pub use super::{
         copy_extent, Array, Array2, Array3, ArrayN, Chunk2, Chunk3, ChunkMap2, ChunkMap3,
-        ChunkMapReader2, ChunkMapReader3, Compressible, Decompressible, FastLz4, ForEach,
+        ChunkMapReader2, ChunkMapReader3, Compressible, Decompressible, ForEach,
         ForEachMut, Get, GetMut, IsEmpty, Local, LocalChunkCache2, LocalChunkCache3, ReadExtent,
         Stride, TransformMap, WriteExtent,
     };
+    #[cfg(feature = "compress-lz4")]
+    pub use super::FastLz4;
+    #[cfg(feature = "compress-snappy")]
+    pub use super::FastSnappy;
 }
 
 pub use compressible_map::{self, Compressible, Decompressible};

--- a/crates/building_blocks_storage/src/transform_map.rs
+++ b/crates/building_blocks_storage/src/transform_map.rs
@@ -33,7 +33,10 @@
 //! # use building_blocks_storage::prelude::*;
 //! # let extent = Extent3::from_min_and_shape(PointN([0; 3]), PointN([16; 3]));
 //! let src = Array3::fill(extent, 0);
+//! # #[cfg(feature = "compress-lz4")]
 //! let mut dst = ChunkMap3::new(PointN([4; 3]), 0, (), FastLz4 { level: 10 });
+//! # #[cfg(feature = "compress-snappy")]
+//! let mut dst = ChunkMap3::new(PointN([4; 3]), 0, (), FastSnappy);
 //! let tfm = TransformMap::new(&src, &|value: i32| value + 1);
 //! copy_extent(&extent, &tfm, &mut dst);
 //! ```
@@ -240,6 +243,7 @@ mod tests {
         assert_eq!(outer_map.get(&PointN([0; 3])), 1);
     }
 
+    #[cfg(feature = "compress-lz4")]
     #[test]
     fn copy_from_transformed_array() {
         let extent = Extent3::from_min_and_shape(PointN([0; 3]), PointN([16; 3]));
@@ -249,6 +253,17 @@ mod tests {
         copy_extent(&extent, &tfm, &mut dst);
     }
 
+    #[cfg(feature = "compress-snappy")]
+    #[test]
+    fn copy_from_transformed_array() {
+        let extent = Extent3::from_min_and_shape(PointN([0; 3]), PointN([16; 3]));
+        let src = Array3::fill(extent, 0);
+        let mut dst = ChunkMap3::new(PointN([4; 3]), 0, (), FastSnappy);
+        let tfm = TransformMap::new(&src, |value: i32| value + 1);
+        copy_extent(&extent, &tfm, &mut dst);
+    }
+
+    #[cfg(feature = "compress-lz4")]
     #[test]
     fn copy_from_transformed_chunk_map_reader() {
         let src_extent = Extent3::from_min_and_shape(PointN([0; 3]), PointN([16; 3]));
@@ -262,6 +277,23 @@ mod tests {
 
         let dst_extent = Extent3::from_min_and_shape(PointN([-16; 3]), PointN([32; 3]));
         let mut dst = ChunkMap3::new(PointN([2; 3]), 0, (), FastLz4 { level: 10 });
+        copy_extent(&dst_extent, &tfm, &mut dst);
+    }
+
+    #[cfg(feature = "compress-snappy")]
+    #[test]
+    fn copy_from_transformed_chunk_map_reader() {
+        let src_extent = Extent3::from_min_and_shape(PointN([0; 3]), PointN([16; 3]));
+        let src_array = Array3::fill(src_extent, 1);
+        let mut src = ChunkMap3::new(PointN([4; 3]), 0, (), FastSnappy);
+        copy_extent(&src_extent, &src_array, &mut src);
+
+        let local_cache = LocalChunkCache3::new();
+        let src_reader = ChunkMapReader3::new(&src, &local_cache);
+        let tfm = TransformMap::new(&src_reader, |value: i32| value + 1);
+
+        let dst_extent = Extent3::from_min_and_shape(PointN([-16; 3]), PointN([32; 3]));
+        let mut dst = ChunkMap3::new(PointN([2; 3]), 0, (), FastSnappy);
         copy_extent(&dst_extent, &tfm, &mut dst);
     }
 }


### PR DESCRIPTION
Hello again!

Here's the PR that adds support for rust-snappy as a compression backend.
I tried to modify the existing structs and traits to make them generic over compression backends but I was in over my head with that so I went with the config-flag based approach.