### PR TITLE
Use default-features=false instead of no-default-features=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to you `features` list, like so:
 ```toml
 [dependencies.building-blocks]
 version = "0.3"
-no-default-features = true
+default-features = false
 features = ["snappy"]
 ```
 

--- a/crates/building_blocks_storage/src/chunk_map.rs
+++ b/crates/building_blocks_storage/src/chunk_map.rs
@@ -14,8 +14,8 @@
 //! written back to the `ChunkMap` using the `flush_chunk_cache` method.
 //!
 //! Two compression backends are usable. The default is LZ4, which has the best tradeoff of
-//! compression rate and speed. The other is Lz4, which has a pure-rust implementation. Lz4
-//! can be used by enabling the "Lz4" feature.
+//! compression rate and speed. The other is snap, which has a pure-rust implementation. Snap
+//! can be used by enabling the "snappy" feature.
 //!
 //! # Example Usage
 //! ```


### PR DESCRIPTION
* fixes an issue where building seemed not to respect our feature selection
* updates docs about lz4 and snap
