### PR TITLE
Upgrade nalegbra

### DIFF
--- a/crates/building_blocks_core/Cargo.toml
+++ b/crates/building_blocks_core/Cargo.toml
@@ -20,5 +20,5 @@ serde = { version = "1.0", features = ["derive"] }
 # Optional, feature-gated.
 glam = { version = "0.13.0", optional = true }
 mint = { version = "0.5.0", optional = true }
-nalgebra = { version = "0.25", optional = true }
+nalgebra = { version = "0.26", optional = true }
 sdfu = { version = "0.3", optional = true }

--- a/crates/building_blocks_search/Cargo.toml
+++ b/crates/building_blocks_search/Cargo.toml
@@ -20,8 +20,8 @@ itertools = "0.9"
 pathfinding = "2.1"
 
 # Optional, feature-gated
-nalgebra = { version = "0.25", optional = true }
-ncollide3d = { version = "0.28", optional = true }
+nalgebra = { version = "0.26", optional = true }
+ncollide3d = { version = "0.29", optional = true }
 
 building_blocks_core = { path = "../building_blocks_core", version = "0.6.0", default-features = false }
 building_blocks_storage = { path = "../building_blocks_storage", version = "0.6.0", default-features = false }


### PR DESCRIPTION
All tests passed. I looked through the [git log for nalgebra](https://github.com/dimforge/nalgebra/compare/v0.25.4...v0.26.0) and couldn't find any breaking change that would apply to this crate. ncollide3d depends on nalgebra so it had to be updated too. Luckily the only change was pretty much just support for the new nalgebra version.