### PR TITLE
Add ModalDownsampler

### DIFF
--- a/crates/building_blocks_storage/src/multiresolution/sampling.rs
+++ b/crates/building_blocks_storage/src/multiresolution/sampling.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, hash::Hash};
+
 use crate::{prelude::*, ArrayIndexer, ArrayNx1};
 
 use building_blocks_core::prelude::*;
@@ -40,6 +42,48 @@ where
 
         for p in ExtentN::from_min_and_shape(PointN::ZERO, dst_shape).iter_points() {
             *dst_chunk.get_mut(Local(dst_min.0 + p)) = src_chunk.get(Local(p << lod_delta));
+        }
+    }
+}
+
+/// A `ChunkDownsampler` that selects the most frequent (i.e. modal) voxel type from each `2x2x2` region, discarding the rest.
+pub struct ModalDownsampler;
+
+impl<N, Src, T> ChunkDownsampler<N, T, Src> for ModalDownsampler
+where
+    N: ArrayIndexer<N>,
+    PointN<N>: IntegerPoint<N>,
+    T: 'static + Copy + Eq + Hash + std::fmt::Debug,
+    Src: Get<Local<N>, Item = T> + IndexedArray<N>,
+{
+    fn downsample(
+        &self,
+        src_chunk: &Src,
+        dst_chunk: &mut ArrayNx1<N, T>,
+        dst_min: Local<N>,
+        lod_delta: u8,
+    ) {
+        // PERF: the access pattern here might not be very cache friendly
+
+        debug_assert!(lod_delta > 0);
+        let lod_delta = lod_delta as i32;
+
+        let lod_scale_factor = 1 << lod_delta;
+        let src_shape_per_point = PointN::fill(lod_scale_factor);
+
+        let dst_shape = src_chunk.extent().shape >> lod_delta;
+        debug_assert!(dst_shape > PointN::ZERO);
+
+        for p_dst in ExtentN::from_min_and_shape(PointN::ZERO, dst_shape).iter_points() {
+            let src_min = p_dst << lod_delta;
+            let src_extent = ExtentN::from_min_and_shape(src_min, src_shape_per_point);
+
+            let mut frequencies = HashMap::new();
+            for p_src in src_extent.iter_points() {
+                *frequencies.entry(src_chunk.get(Local(p_src))).or_insert(0) += 1;
+            }
+            let (voxel, _frequency) = frequencies.iter().max_by(|a, b| a.1.cmp(b.1)).unwrap();
+            *dst_chunk.get_mut(Local(dst_min.0 + p_dst)) = *voxel;
         }
     }
 }


### PR DESCRIPTION
Something like this I think. In the test I was trying to use 1x1x1 lod0 chunks and a 2x2x2 superchunk and lod0 extent, thinking that it would downsample the 2x2x2 extent of lod0 to a 1x1x1 lod1, but I hit the assertion on the dst shape being `Point3i::ZERO`. I don't understand why.