### PR TITLE
OctreeChunkIndex: Fix num_lods calculation

### DIFF
--- a/crates/building_blocks_storage/src/octree_chunk_index.rs
+++ b/crates/building_blocks_storage/src/octree_chunk_index.rs
@@ -120,7 +120,7 @@ impl OctreeChunkIndex {
             .x()
             .trailing_zeros() as u8;
         let chunk_log2 = self.chunk_shape().x().trailing_zeros() as u8;
-        let num_lods = superchunk_log2 - chunk_log2;
+        let num_lods = superchunk_log2 - chunk_log2 + 1;
 
         ClipMapConfig3 {
             num_lods,


### PR DESCRIPTION
```
superchunk_shape =  2^(chunk_log2 + num_lods - 1)
log2(superchunk_shape) = log2(2^(chunk_log2 + num_lods - 1)) = (chunk_log2 + num_lods - 1) * log2(2) = (chunk_log2 + num_lods - 1)
num_lods = log2(superchunk_shape) - chunk_log2 + 1
```