### PR TITLE
Improve terrain generation in lod_terrain example

### DIFF
--- a/crates/utilities/src/noise.rs
+++ b/crates/utilities/src/noise.rs
@@ -1,8 +1,8 @@
 use building_blocks_core::prelude::*;
-use building_blocks_storage::Array3x1;
+use building_blocks_storage::{Array3x1, Array3x3, Channel};
 use simdnoise::NoiseBuilder;
 
-pub fn noise_array(extent: Extent3i, freq: f32, seed: i32) -> Array3x1<f32> {
+pub fn noise_array(extent: Extent3i, freq: f32, seed: i32, octaves: u8) -> Array3x1<f32> {
     let min = Point3f::from(extent.minimum);
     let (noise, _min_val, _max_val) = NoiseBuilder::fbm_3d_offset(
         min.x(),
@@ -14,7 +14,56 @@ pub fn noise_array(extent: Extent3i, freq: f32, seed: i32) -> Array3x1<f32> {
     )
     .with_freq(freq)
     .with_seed(seed)
+    .with_octaves(octaves)
     .generate();
 
     Array3x1::new_one_channel(extent, noise)
+}
+
+pub fn noise_array_warp(extent: Extent3i, freq: f32, seed: i32) -> Array3x3<f32, f32, f32> {
+    let min = Point3f::from(extent.minimum);
+    let (noise_x, _min_val, _max_val) = NoiseBuilder::gradient_3d_offset(
+        min.x(),
+        extent.shape.x() as usize,
+        min.y(),
+        extent.shape.y() as usize,
+        min.z(),
+        extent.shape.z() as usize,
+    )
+    .with_freq(freq)
+    .with_seed(seed)
+    .generate();
+
+    let (noise_y, _min_val, _max_val) = NoiseBuilder::gradient_3d_offset(
+        min.x(),
+        extent.shape.x() as usize,
+        min.y(),
+        extent.shape.y() as usize,
+        min.z(),
+        extent.shape.z() as usize,
+    )
+    .with_freq(freq)
+    .with_seed(seed + 1)
+    .generate();
+
+    let (noise_z, _min_val, _max_val) = NoiseBuilder::gradient_3d_offset(
+        min.x(),
+        extent.shape.x() as usize,
+        min.y(),
+        extent.shape.y() as usize,
+        min.z(),
+        extent.shape.z() as usize,
+    )
+    .with_freq(freq)
+    .with_seed(seed + 2)
+    .generate();
+
+    Array3x3::new(
+        extent,
+        (
+            Channel::new(noise_x),
+            Channel::new(noise_y),
+            Channel::new(noise_z),
+        ),
+    )
 }

--- a/examples/bevy_utilities/src/noise.rs
+++ b/examples/bevy_utilities/src/noise.rs
@@ -1,7 +1,7 @@
 use bevy::tasks::TaskPool;
 use building_blocks_core::prelude::*;
-use building_blocks_storage::Array3x1;
-use utilities::noise::noise_array;
+use building_blocks_storage::{Array3x1, Array3x3};
+use utilities::noise::{noise_array, noise_array_warp};
 
 pub fn generate_noise_chunks(
     pool: &TaskPool,
@@ -9,6 +9,7 @@ pub fn generate_noise_chunks(
     chunk_shape: Point3i,
     freq: f32,
     seed: i32,
+    octaves: u8,
 ) -> Vec<(Point3i, Array3x1<f32>)> {
     pool.scope(|s| {
         for p in chunks_extent.iter_points() {
@@ -16,7 +17,26 @@ pub fn generate_noise_chunks(
                 let chunk_min = p * chunk_shape;
                 let chunk_extent = Extent3i::from_min_and_shape(chunk_min, chunk_shape);
 
-                (chunk_min, noise_array(chunk_extent, freq, seed))
+                (chunk_min, noise_array(chunk_extent, freq, seed, octaves))
+            });
+        }
+    })
+}
+
+pub fn generate_noise_chunks_warp(
+    pool: &TaskPool,
+    chunks_extent: Extent3i,
+    chunk_shape: Point3i,
+    freq: f32,
+    seed: i32,
+) -> Vec<(Point3i, Array3x3<f32, f32, f32>)> {
+    pool.scope(|s| {
+        for p in chunks_extent.iter_points() {
+            s.spawn(async move {
+                let chunk_min = p * chunk_shape;
+                let chunk_extent = Extent3i::from_min_and_shape(chunk_min, chunk_shape);
+
+                (chunk_min, noise_array_warp(chunk_extent, freq, seed))
             });
         }
     })

--- a/examples/lod_terrain/blocky_voxel_map.rs
+++ b/examples/lod_terrain/blocky_voxel_map.rs
@@ -115,8 +115,8 @@ impl VoxelMap for BlockyVoxelMap {
             // Rescale the noise.
             let array = noise.array_mut();
             let extent = *array.extent();
-            array.for_each_mut(&extent, |p: Point3i, x: &mut f32| {
-                *x = p.y() as f32 + *x * scale;
+            array.for_each_mut(&extent, |_: (), x: &mut f32| {
+                *x *= scale;
             });
 
             noise_chunk_map.write_chunk(ChunkKey::new(0, chunk_min), noise);
@@ -127,7 +127,7 @@ impl VoxelMap for BlockyVoxelMap {
             chunk.for_each_mut(&extent, |p: Point3i, v: &mut Voxel| {
                 let (warp_x, warp_y, warp_z) = warp.get(p);
                 let sample_p = p + PointN([warp_x as i32, warp_y as i32, warp_z as i32]);
-                *v = if p.y() as f32 + noise_chunk_map.get_point(0, sample_p) * scale < 0.0 {
+                *v = if p.y() as f32 + noise_chunk_map.get_point(0, sample_p) < 0.0 {
                     Voxel::FILLED
                 } else {
                     Voxel::EMPTY

--- a/examples/lod_terrain/blocky_voxel_map.rs
+++ b/examples/lod_terrain/blocky_voxel_map.rs
@@ -1,6 +1,9 @@
 use crate::voxel_map::VoxelMap;
 
-use bevy_utilities::{bevy::tasks::ComputeTaskPool, noise::generate_noise_chunks};
+use bevy_utilities::{
+    bevy::tasks::ComputeTaskPool,
+    noise::{generate_noise_chunks, generate_noise_chunks_warp},
+};
 use building_blocks::{
     mesh::{
         greedy_quads, padded_greedy_quads_chunk_extent, GreedyQuadsBuffer, IsOpaque, MergeVoxel,
@@ -17,9 +20,11 @@ const SUPERCHUNK_SHAPE: Point3i = PointN([1 << (CHUNK_LOG2 + NUM_LODS as i32 - 1
 const CLIP_BOX_RADIUS: u16 = 8;
 
 const WORLD_CHUNKS_EXTENT: Extent3i = Extent3i {
-    minimum: PointN([-100, 0, -100]),
-    shape: PointN([200, 1, 200]),
+    minimum: PointN([-50, -4, -50]),
+    shape: PointN([100, 8, 100]),
 };
+
+const AMBIENT_VALUE: f32 = 0.0;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Voxel(pub u8);
@@ -57,18 +62,79 @@ pub struct BlockyVoxelMap {
 impl VoxelMap for BlockyVoxelMap {
     type MeshBuffers = MeshBuffers;
 
-    fn generate(pool: &ComputeTaskPool, freq: f32, scale: f32, seed: i32) -> Self {
-        let noise_chunks =
-            generate_noise_chunks(pool, Self::world_chunks_extent(), CHUNK_SHAPE, freq, seed);
+    fn generate(
+        pool: &ComputeTaskPool,
+        freq: f32,
+        scale: f32,
+        seed: i32,
+        octaves: u8,
+        freq_warp: f32,
+        scale_warp: f32,
+    ) -> Self {
+        let noise_chunks = generate_noise_chunks(
+            pool,
+            Self::world_chunks_extent(),
+            CHUNK_SHAPE,
+            freq,
+            seed,
+            octaves,
+        );
+
+        let noise_chunks_warp = generate_noise_chunks_warp(
+            pool,
+            Self::world_chunks_extent(),
+            CHUNK_SHAPE,
+            freq_warp,
+            seed,
+        );
+        let warp_builder =
+            ChunkMapBuilder3x3::new(CHUNK_SHAPE, (AMBIENT_VALUE, AMBIENT_VALUE, AMBIENT_VALUE));
+
+        let mut warp_chunks = warp_builder.build_with_hash_map_storage();
+
+        for (chunk_min, mut noise) in noise_chunks_warp.into_iter() {
+            // Rescale the noise.
+            let array = noise.array_mut();
+            let extent = *array.extent();
+            array.for_each_mut(&extent, |_: (), (x, y, z)| {
+                *x *= scale_warp;
+                *y *= scale_warp;
+                *z *= scale_warp;
+            });
+
+            warp_chunks.write_chunk(ChunkKey::new(0, chunk_min), noise);
+        }
+
+        let noise_builder = ChunkMapBuilder3x1::new(CHUNK_SHAPE, AMBIENT_VALUE);
+        let mut noise_chunk_map = noise_builder.build_with_hash_map_storage();
 
         let builder = ChunkMapBuilder3x1::new(CHUNK_SHAPE, Voxel::EMPTY);
         let mut chunks = builder.build_with_hash_map_storage();
 
-        for (chunk_min, noise) in noise_chunks.into_iter() {
-            chunks.write_chunk(
-                ChunkKey::new(0, chunk_min),
-                blocky_voxels_from_noise(&noise, scale),
-            );
+        for (chunk_min, mut noise) in noise_chunks.into_iter() {
+            // Rescale the noise.
+            let array = noise.array_mut();
+            let extent = *array.extent();
+            array.for_each_mut(&extent, |p: Point3i, x: &mut f32| {
+                *x = p.y() as f32 + *x * scale;
+            });
+
+            noise_chunk_map.write_chunk(ChunkKey::new(0, chunk_min), noise);
+        }
+        for (warp_key, warp) in warp_chunks.take_storage() {
+            let extent = warp.extent();
+            let mut chunk = Array3x1::fill(*extent, Voxel::EMPTY);
+            chunk.for_each_mut(&extent, |p: Point3i, v: &mut Voxel| {
+                let (warp_x, warp_y, warp_z) = warp.get(p);
+                let sample_p = p + PointN([warp_x as i32, warp_y as i32, warp_z as i32]);
+                *v = if p.y() as f32 + noise_chunk_map.get_point(0, sample_p) * scale < 0.0 {
+                    Voxel::FILLED
+                } else {
+                    Voxel::EMPTY
+                }
+            });
+
+            chunks.write_chunk(warp_key, chunk);
         }
 
         let index = OctreeChunkIndex::index_chunk_map(SUPERCHUNK_SHAPE, NUM_LODS, &chunks);
@@ -150,22 +216,6 @@ impl VoxelMap for BlockyVoxelMap {
             Some(mesh)
         }
     }
-}
-
-fn blocky_voxels_from_noise(noise: &Array3x1<f32>, scale: f32) -> Array3x1<Voxel> {
-    let mut voxels = Array3x1::fill(*noise.extent(), Voxel::EMPTY);
-
-    // Convert the f32 noise into Voxels.
-    let sdf_voxel_noise = TransformMap::new(noise, |d: f32| {
-        if scale * d < 0.0 {
-            Voxel::FILLED
-        } else {
-            Voxel::EMPTY
-        }
-    });
-    copy_extent(noise.extent(), &sdf_voxel_noise, &mut voxels);
-
-    voxels
 }
 
 pub struct MeshBuffers {

--- a/examples/lod_terrain/lod_terrain.rs
+++ b/examples/lod_terrain/lod_terrain.rs
@@ -80,10 +80,13 @@ fn setup<Map: VoxelMap>(
     // wireframe_config.global = true;
 
     // Generate a voxel map from noise.
-    let freq = 0.15;
-    let scale = 1.0;
+    let freq = 0.25;
+    let scale = 4.0;
     let seed = 666;
-    let map = Map::generate(&*pool, freq, scale, seed);
+    let octaves = 9;
+    let freq_warp = 0.015;
+    let scale_warp = 500.0;
+    let map = Map::generate(&*pool, freq, scale, seed, octaves, freq_warp, scale_warp);
 
     // Queue up commands to initialize the chunk meshes to their appropriate LODs given the starting camera position.
     let init_lod0_center = ChunkUnits(Point3i::ZERO);

--- a/examples/lod_terrain/lod_terrain.rs
+++ b/examples/lod_terrain/lod_terrain.rs
@@ -81,11 +81,11 @@ fn setup<Map: VoxelMap>(
 
     // Generate a voxel map from noise.
     let freq = 0.25;
-    let scale = 4.0;
+    let scale = 5.0;
     let seed = 666;
     let octaves = 9;
     let freq_warp = 0.015;
-    let scale_warp = 500.0;
+    let scale_warp = 600.0;
     let map = Map::generate(&*pool, freq, scale, seed, octaves, freq_warp, scale_warp);
 
     // Queue up commands to initialize the chunk meshes to their appropriate LODs given the starting camera position.

--- a/examples/lod_terrain/smooth_voxel_map.rs
+++ b/examples/lod_terrain/smooth_voxel_map.rs
@@ -84,8 +84,8 @@ impl VoxelMap for SmoothVoxelMap {
             // Rescale the noise.
             let array = noise.array_mut();
             let extent = *array.extent();
-            array.for_each_mut(&extent, |p: Point3i, x: &mut f32| {
-                *x = p.y() as f32 + *x * scale;
+            array.for_each_mut(&extent, |_: (), x: &mut f32| {
+                *x *= scale;
             });
 
             noise_chunk_map.write_chunk(ChunkKey::new(0, chunk_min), noise);
@@ -96,7 +96,7 @@ impl VoxelMap for SmoothVoxelMap {
             chunk.for_each_mut(&extent, |p: Point3i, d: &mut f32| {
                 let (warp_x, warp_y, warp_z) = warp.get(p);
                 let sample_p = p + PointN([warp_x as i32, warp_y as i32, warp_z as i32]);
-                *d = p.y() as f32 + noise_chunk_map.get_point(0, sample_p) * scale
+                *d = p.y() as f32 + noise_chunk_map.get_point(0, sample_p)
             });
 
             chunks.write_chunk(warp_key, chunk);

--- a/examples/lod_terrain/smooth_voxel_map.rs
+++ b/examples/lod_terrain/smooth_voxel_map.rs
@@ -1,6 +1,9 @@
 use crate::voxel_map::VoxelMap;
 
-use bevy_utilities::{bevy::tasks::ComputeTaskPool, noise::generate_noise_chunks};
+use bevy_utilities::{
+    bevy::tasks::ComputeTaskPool,
+    noise::{generate_noise_chunks, generate_noise_chunks_warp},
+};
 use building_blocks::{
     mesh::{padded_surface_nets_chunk_extent, surface_nets, PosNormMesh, SurfaceNetsBuffer},
     prelude::*,
@@ -14,11 +17,11 @@ const SUPERCHUNK_SHAPE: Point3i = PointN([1 << (CHUNK_LOG2 + NUM_LODS as i32 - 1
 const CLIP_BOX_RADIUS: u16 = 12;
 
 const WORLD_CHUNKS_EXTENT: Extent3i = Extent3i {
-    minimum: PointN([-100, 0, -100]),
-    shape: PointN([200, 1, 200]),
+    minimum: PointN([-50, -4, -50]),
+    shape: PointN([100, 8, 100]),
 };
 
-const AMBIENT_VALUE: f32 = 1.0;
+const AMBIENT_VALUE: f32 = 0.0;
 
 pub struct SmoothVoxelMap {
     chunks: ChunkHashMap3x1<f32>,
@@ -28,9 +31,51 @@ pub struct SmoothVoxelMap {
 impl VoxelMap for SmoothVoxelMap {
     type MeshBuffers = MeshBuffers;
 
-    fn generate(pool: &ComputeTaskPool, freq: f32, scale: f32, seed: i32) -> Self {
-        let noise_chunks =
-            generate_noise_chunks(pool, Self::world_chunks_extent(), CHUNK_SHAPE, freq, seed);
+    fn generate(
+        pool: &ComputeTaskPool,
+        freq: f32,
+        scale: f32,
+        seed: i32,
+        octaves: u8,
+        freq_warp: f32,
+        scale_warp: f32,
+    ) -> Self {
+        let noise_chunks = generate_noise_chunks(
+            pool,
+            Self::world_chunks_extent(),
+            CHUNK_SHAPE,
+            freq,
+            seed,
+            octaves,
+        );
+
+        let noise_chunks_warp = generate_noise_chunks_warp(
+            pool,
+            Self::world_chunks_extent(),
+            CHUNK_SHAPE,
+            freq_warp,
+            seed,
+        );
+        let warp_builder =
+            ChunkMapBuilder3x3::new(CHUNK_SHAPE, (AMBIENT_VALUE, AMBIENT_VALUE, AMBIENT_VALUE));
+
+        let mut warp_chunks = warp_builder.build_with_hash_map_storage();
+
+        for (chunk_min, mut noise) in noise_chunks_warp.into_iter() {
+            // Rescale the noise.
+            let array = noise.array_mut();
+            let extent = *array.extent();
+            array.for_each_mut(&extent, |_: (), (x, y, z)| {
+                *x *= scale_warp;
+                *y *= scale_warp;
+                *z *= scale_warp;
+            });
+
+            warp_chunks.write_chunk(ChunkKey::new(0, chunk_min), noise);
+        }
+
+        let noise_builder = ChunkMapBuilder3x1::new(CHUNK_SHAPE, AMBIENT_VALUE);
+        let mut noise_chunk_map = noise_builder.build_with_hash_map_storage();
 
         let builder = ChunkMapBuilder3x1::new(CHUNK_SHAPE, AMBIENT_VALUE);
         let mut chunks = builder.build_with_hash_map_storage();
@@ -39,10 +84,22 @@ impl VoxelMap for SmoothVoxelMap {
             // Rescale the noise.
             let array = noise.array_mut();
             let extent = *array.extent();
-            array.for_each_mut(&extent, |_: (), x| {
-                *x *= scale;
+            array.for_each_mut(&extent, |p: Point3i, x: &mut f32| {
+                *x = p.y() as f32 + *x * scale;
             });
-            chunks.write_chunk(ChunkKey::new(0, chunk_min), noise);
+
+            noise_chunk_map.write_chunk(ChunkKey::new(0, chunk_min), noise);
+        }
+        for (warp_key, warp) in warp_chunks.take_storage() {
+            let extent = warp.extent();
+            let mut chunk = Array3x1::fill(*extent, AMBIENT_VALUE);
+            chunk.for_each_mut(&extent, |p: Point3i, d: &mut f32| {
+                let (warp_x, warp_y, warp_z) = warp.get(p);
+                let sample_p = p + PointN([warp_x as i32, warp_y as i32, warp_z as i32]);
+                *d = p.y() as f32 + noise_chunk_map.get_point(0, sample_p) * scale
+            });
+
+            chunks.write_chunk(warp_key, chunk);
         }
 
         let index = OctreeChunkIndex::index_chunk_map(SUPERCHUNK_SHAPE, NUM_LODS, &chunks);

--- a/examples/lod_terrain/voxel_map.rs
+++ b/examples/lod_terrain/voxel_map.rs
@@ -8,7 +8,15 @@ use building_blocks::{
 pub trait VoxelMap: ecs::component::Component {
     type MeshBuffers: Send;
 
-    fn generate(pool: &ComputeTaskPool, freq: f32, scale: f32, seed: i32) -> Self;
+    fn generate(
+        pool: &ComputeTaskPool,
+        freq: f32,
+        scale: f32,
+        seed: i32,
+        octaves: u8,
+        freq_heightmap: f32,
+        scale_heightmap: f32,
+    ) -> Self;
 
     fn world_chunks_extent() -> Extent3i;
     fn chunk_log2() -> i32;


### PR DESCRIPTION
I implemented some of the basic terrain generation techniques outlined here: https://developer.nvidia.com/gpugems/gpugems3/part-i-geometry/chapter-1-generating-complex-procedural-terrains-using-gpu

Specifically, I added a base layer at y=0 and offset the noise lookup coordinates with a warp noise (which generates 3d offset vectors at each point). This gives us some amount of overhangs and interesting features to test against, although I didn't spend too much time tuning the relative frequencies and scales of the two noise textures to achieve anything super realistic.