### PR TITLE
Inline Crates and Hide Prelude in Docs

### DIFF
--- a/crates/building_blocks_core/src/lib.rs
+++ b/crates/building_blocks_core/src/lib.rs
@@ -21,6 +21,7 @@ pub use point::{point_traits::*, Point2, Point2f, Point2i, Point3, Point3f, Poin
 pub use bytemuck;
 pub use num;
 
+#[doc(hidden)]
 pub mod prelude {
     pub use super::{
         point::point_traits::*, Axis2, Axis3, Bounded, ConstZero, Distance, DotProduct, Extent2,

--- a/crates/building_blocks_storage/src/lib.rs
+++ b/crates/building_blocks_storage/src/lib.rs
@@ -68,6 +68,7 @@ pub type SmallKeyHashMap<K, V> = ahash::AHashMap<K, V>;
 pub type SmallKeyHashSet<K> = ahash::AHashSet<K>;
 pub type SmallKeyBuildHasher = ahash::RandomState;
 
+#[doc(hidden)]
 pub mod prelude {
     pub use super::{
         copy_extent, Chunk, ChunkKey, ChunkKey2, ChunkKey3, ChunkMapBuilder, ChunkReadStorage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod search {
     pub use building_blocks_search::*;
 }
 
+#[doc(hidden)]
 pub mod prelude {
     pub use super::core::prelude::*;
     pub use super::storage::prelude::*;


### PR DESCRIPTION
If you try to search the building-blocks crate on docs.rs, you get no results. This is confusing to users ( or it was for me ), then I realized that the whole contents of the `building-blocks` crate was re-exports, and that was why search wasn't working.

This change will inline the documentation for the re-exported crates, allowing all of them to be searched at the same time without having to jump between the different crates.

This also hides the prelude from the docs so that you don't get excessive duplicates when searching.