### PR TITLE
On-the-fly generation

### DIFF
--- a/examples/bevy_utilities/src/noise.rs
+++ b/examples/bevy_utilities/src/noise.rs
@@ -30,16 +30,13 @@ pub fn generate_noise_chunks2(
 }
 
 pub fn generate_noise_chunk3(
-    chunk_min: Point3i,
-    chunk_shape: Point3i,
+    chunk_extent: Extent3i,
     freq: f32,
     scale: f32,
     seed: i32,
     octaves: u8,
     subsurface_only: bool,
 ) -> Option<Array3x1<f32>> {
-    let chunk_extent = Extent3i::from_min_and_shape(chunk_min, chunk_shape);
-
     let mut array = noise_array3(chunk_extent, freq, seed, octaves);
 
     if subsurface_only {
@@ -80,7 +77,8 @@ pub fn generate_noise_chunks3(
         for p in chunks_extent.0.iter_points() {
             s.spawn(async move {
                 let chunk_min = p * chunk_shape;
-                generate_noise_chunk3(chunk_min, chunk_shape, freq, scale, seed, octaves, subsurface_only).and_then(|chunk| Some((chunk_min, chunk)))
+                let chunk_extent = Extent3i::from_min_and_shape(chunk_min, chunk_shape);
+                generate_noise_chunk3(chunk_extent, freq, scale, seed, octaves, subsurface_only).map(|chunk| (chunk_min, chunk))
             });
         }
     }).into_iter().filter_map(|x| x).collect()

--- a/examples/lod_terrain/blocky_voxel_map.rs
+++ b/examples/lod_terrain/blocky_voxel_map.rs
@@ -130,9 +130,13 @@ impl VoxelMap for BlockyVoxelMap {
         self.chunks.write_chunk(key, chunk);
     }
 
-    fn downsample_extent(&mut self, extent: Extent3i) {
-        self.chunks
-            .downsample_extent(&PointDownsampler, 0, self.chunks.root_lod(), extent);
+    fn downsample_extent_into_self(&mut self, extent: Extent3i) {
+        self.chunks.downsample_extent_into_self(
+            &PointDownsampler,
+            0,
+            self.chunks.root_lod(),
+            extent,
+        );
     }
 
     fn config(&self) -> &MapConfig {

--- a/examples/lod_terrain/chunk_generator.rs
+++ b/examples/lod_terrain/chunk_generator.rs
@@ -101,6 +101,6 @@ fn write_chunks<Map: VoxelMap>(
         }
     }
     for extent in extents_to_downsample.into_iter() {
-        voxel_map.downsample_extent(extent);
+        voxel_map.downsample_extent_into_self(extent);
     }
 }

--- a/examples/lod_terrain/chunk_generator.rs
+++ b/examples/lod_terrain/chunk_generator.rs
@@ -66,11 +66,15 @@ fn apply_chunk_commands<Map: VoxelMap>(
                     ChunkCommand::Create(key) => {
                         num_commands_processed += 1;
                         num_chunks_created += 1;
-                        extents_to_downsample.push(voxel_map.chunk_extent_at_lower_lod(key, 0));
+                        let mut needs_downsampling = false;
                         for chunk_min in voxel_map.iter_chunks_for_key(key) {
                             if !voxel_map.chunk_is_generated(chunk_min) {
+                                needs_downsampling = true;
                                 make_chunks(chunk_min)
                             }
+                        }
+                        if needs_downsampling {
+                            extents_to_downsample.push(voxel_map.chunk_extent_at_lower_lod(key, 0));
                         }
                     }
                 }

--- a/examples/lod_terrain/chunk_generator.rs
+++ b/examples/lod_terrain/chunk_generator.rs
@@ -1,0 +1,102 @@
+use crate::voxel_map::VoxelMap;
+
+use bevy_utilities::bevy::{prelude::*, tasks::ComputeTaskPool};
+use building_blocks::prelude::{Array3x1, ChunkKey, ChunkKey3, Extent3i, Point3i};
+
+use std::collections::VecDeque;
+
+fn max_chunk_creations_per_frame(pool: &ComputeTaskPool) -> usize {
+    40 * pool.thread_num()
+}
+
+#[derive(Default)]
+pub struct ChunkCommandQueue {
+    commands: VecDeque<ChunkCommand>,
+}
+
+impl ChunkCommandQueue {
+    pub fn enqueue(&mut self, command: ChunkCommand) {
+        self.commands.push_front(command);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChunkCommand {
+    Create(ChunkKey3),
+}
+
+/// Generates new chunks
+pub fn chunk_generator_system<Map: VoxelMap>(
+    pool: Res<ComputeTaskPool>,
+    mut voxel_map: ResMut<Map>,
+    mut chunk_commands: ResMut<ChunkCommandQueue>,
+) {
+    let (new_chunks, extents_to_downsample) =
+        apply_chunk_commands(&*voxel_map, &*pool, &mut *chunk_commands);
+    write_chunks(&mut *voxel_map, new_chunks, extents_to_downsample);
+}
+
+fn apply_chunk_commands<Map: VoxelMap>(
+    voxel_map: &Map,
+    pool: &ComputeTaskPool,
+    chunk_commands: &mut ChunkCommandQueue,
+) -> (Vec<(Point3i, Option<Array3x1<Map::Voxel>>)>, Vec<Extent3i>) {
+    let max_chunks_per_frame = max_chunk_creations_per_frame(pool);
+
+    let mut num_commands_processed = 0;
+    let mut extents_to_downsample = Vec::new();
+
+    (
+        pool.scope(|s| {
+            let mut make_chunks = |chunk_min: Point3i| {
+                s.spawn(async move { (chunk_min, voxel_map.generate_chunk(chunk_min)) });
+            };
+
+            let mut num_chunks_created = 0;
+            for command in chunk_commands.commands.iter().rev().cloned() {
+                match command {
+                    ChunkCommand::Create(key) => {
+                        num_commands_processed += 1;
+                        num_chunks_created += 1;
+                        extents_to_downsample.push(voxel_map.chunk_extent_at_lower_lod(key, 0));
+                        for chunk_min in voxel_map.iter_chunks_for_key(key) {
+                            if !voxel_map.chunk_is_generated(chunk_min) {
+                                make_chunks(chunk_min)
+                            }
+                        }
+                    }
+                }
+                if num_chunks_created >= max_chunks_per_frame {
+                    break;
+                }
+            }
+
+            let new_length = chunk_commands.len() - num_commands_processed;
+            chunk_commands.commands.truncate(new_length);
+        }),
+        extents_to_downsample,
+    )
+}
+
+fn write_chunks<Map: VoxelMap>(
+    voxel_map: &mut Map,
+    chunks: Vec<(Point3i, Option<Array3x1<Map::Voxel>>)>,
+    extents_to_downsample: Vec<Extent3i>,
+) {
+    for (chunk_min, chunk) in chunks.into_iter() {
+        if let Some(chunk) = chunk {
+            voxel_map.write_chunk(ChunkKey::new(0, chunk_min), chunk);
+        }
+    }
+    for extent in extents_to_downsample.into_iter() {
+        voxel_map.downsample_extent(extent);
+    }
+}

--- a/examples/lod_terrain/level_of_detail.rs
+++ b/examples/lod_terrain/level_of_detail.rs
@@ -49,7 +49,7 @@ pub fn level_of_detail_system<Map: VoxelMap>(
         lod_state.old_lod0_center,
         lod_state.lod0_center,
         |update| match update {
-            ClipEvent3::Enter(chunk_key) => {
+            ClipEvent3::Enter(chunk_key, is_active_lod) => {
                 let MapConfig {
                     chunk_exponent,
                     world_chunks_extent,
@@ -57,16 +57,38 @@ pub fn level_of_detail_system<Map: VoxelMap>(
                 } = *voxel_map.config();
                 let world_chunks_extent_lod0 = world_chunks_extent.0 << chunk_exponent;
                 let lod0_extent = voxel_map.chunk_extent_at_lower_lod(chunk_key, 0);
-                // Only allow generation and meshing of chunks with their minimum within
-                // the world extent y-height
-                if lod0_extent.minimum.y() >= world_chunks_extent_lod0.minimum.y()
-                    && lod0_extent.minimum.y() < world_chunks_extent_lod0.max().y()
+
+                // Only generate chunks at lod 0 and within the world extent y-height
+                if chunk_key.lod == 0
+                    && lod0_extent.minimum.y() >= world_chunks_extent_lod0.minimum.y()
+                    && lod0_extent.minimum.y() <= world_chunks_extent_lod0.max().y()
+                    && lod0_extent.max().y() >= world_chunks_extent_lod0.minimum.y()
+                    && lod0_extent.max().y() <= world_chunks_extent_lod0.max().y()
                 {
                     chunk_commands.enqueue(ChunkCommand::Create(chunk_key));
-                    mesh_commands.enqueue(MeshCommand::Create(chunk_key));
+                }
+
+                if (lod0_extent.minimum.y() >= world_chunks_extent_lod0.minimum.y()
+                    && lod0_extent.minimum.y() <= world_chunks_extent_lod0.max().y())
+                    || (lod0_extent.max().y() >= world_chunks_extent_lod0.minimum.y()
+                        && lod0_extent.max().y() <= world_chunks_extent_lod0.max().y())
+                {
+                    // Only downsample lods > 0 that intersect the world extent
+                    if chunk_key.lod > 0 {
+                        chunk_commands.enqueue(ChunkCommand::Downsample(chunk_key));
+                    }
+                    // Only mesh if the lod is active, and the extent intersects the world extent
+                    if is_active_lod {
+                        mesh_commands.enqueue(MeshCommand::Create(chunk_key));
+                    }
                 }
             }
-            ClipEvent3::Exit(chunk_key) => mesh_commands.enqueue(MeshCommand::Destroy(chunk_key)),
+            ClipEvent3::Exit(chunk_key, was_active_lod) => {
+                if was_active_lod {
+                    chunk_commands.enqueue(ChunkCommand::Destroy(chunk_key));
+                    mesh_commands.enqueue(MeshCommand::Destroy(chunk_key));
+                }
+            }
             ClipEvent3::Split(_) | ClipEvent3::Merge(_) => {
                 mesh_commands.enqueue(MeshCommand::Update(update))
             }

--- a/examples/lod_terrain/map.ron
+++ b/examples/lod_terrain/map.ron
@@ -4,7 +4,7 @@
     detail: 6.0,
     clip_radius: 2000.0,
     world_chunks_extent: ((
-        minimum: ((-50, -2, -50)),
+        minimum: ((-50, 0, -50)),
         shape: ((100, 4, 100)),
     )),
     noise: (

--- a/examples/lod_terrain/mesh_generator.rs
+++ b/examples/lod_terrain/mesh_generator.rs
@@ -42,6 +42,7 @@ impl MeshCommandQueue {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MeshCommand {
     Create(ChunkKey3),
+    Destroy(ChunkKey3),
     Update(ClipEvent3),
 }
 
@@ -113,6 +114,12 @@ fn apply_mesh_commands<Map: VoxelMap>(
                     num_commands_processed += 1;
                     num_meshes_created += 1;
                     make_mesh(key)
+                }
+                MeshCommand::Destroy(key) => {
+                    num_commands_processed += 1;
+                    if let Some(entity) = chunk_meshes.entities.remove(&key) {
+                        commands.entity(entity).despawn();
+                    }
                 }
                 MeshCommand::Update(update) => {
                     num_commands_processed += 1;

--- a/examples/lod_terrain/mesh_generator.rs
+++ b/examples/lod_terrain/mesh_generator.rs
@@ -7,7 +7,10 @@ use bevy_utilities::{
 };
 use building_blocks::{
     mesh::*,
-    storage::{SmallKeyHashMap, prelude::{ChunkKey3, ClipEvent3}},
+    storage::{
+        prelude::{ChunkKey3, ClipEvent3},
+        SmallKeyHashMap,
+    },
 };
 
 use std::{cell::RefCell, collections::VecDeque};

--- a/examples/lod_terrain/smooth_voxel_map.rs
+++ b/examples/lod_terrain/smooth_voxel_map.rs
@@ -1,6 +1,9 @@
 use crate::voxel_map::{MapConfig, NoiseConfig, VoxelMap};
 
-use bevy_utilities::{bevy::tasks::ComputeTaskPool, noise::generate_noise_chunks3};
+use bevy_utilities::{
+    bevy::tasks::ComputeTaskPool,
+    noise::{generate_noise_chunk3, generate_noise_chunks3},
+};
 use building_blocks::{
     mesh::{padded_surface_nets_chunk_extent, surface_nets, PosNormMesh, SurfaceNetsBuffer},
     prelude::*,
@@ -16,6 +19,7 @@ pub struct SmoothVoxelMap {
 
 impl VoxelMap for SmoothVoxelMap {
     type MeshBuffers = MeshBuffers;
+    type Voxel = f32;
 
     fn generate(pool: &ComputeTaskPool, config: MapConfig) -> Self {
         let MapConfig {
@@ -60,6 +64,46 @@ impl VoxelMap for SmoothVoxelMap {
         chunks.downsample_extent_into_self(&SdfMeanDownsampler, 0, root_lod, config.world_extent());
 
         Self { chunks, config }
+    }
+
+    fn chunk_extent_at_lower_lod(&self, key: ChunkKey3, lod: u8) -> Extent3i {
+        self.chunks.indexer.chunk_extent_at_lower_lod(key, lod)
+    }
+
+    fn iter_chunks_for_key(&self, key: ChunkKey3) -> Box<dyn Iterator<Item = Point3i>> {
+        let lod0_extent = self.chunks.indexer.chunk_extent_at_lower_lod(key, 0);
+        Box::new(self.chunks.indexer.chunk_mins_for_extent(&lod0_extent))
+    }
+
+    fn chunk_is_generated(&self, minimum: Point3i) -> bool {
+        self.chunks.get_chunk(ChunkKey::new(0, minimum)).is_some()
+    }
+
+    fn generate_chunk(&self, minimum: Point3i) -> Option<Array3x1<Self::Voxel>> {
+        let MapConfig {
+            chunk_exponent,
+            noise:
+                NoiseConfig {
+                    freq,
+                    scale,
+                    seed,
+                    octaves,
+                },
+            ..
+        } = self.config;
+
+        let chunk_shape = Point3i::fill(1 << chunk_exponent);
+
+        generate_noise_chunk3(minimum, chunk_shape, freq, scale, seed, octaves, true)
+    }
+
+    fn write_chunk(&mut self, key: ChunkKey3, chunk: Array3x1<Self::Voxel>) {
+        self.chunks.write_chunk(key, chunk);
+    }
+
+    fn downsample_extent(&mut self, extent: Extent3i) {
+        self.chunks
+            .downsample_extent(&PointDownsampler, 0, self.chunks.root_lod(), extent);
     }
 
     fn config(&self) -> &MapConfig {

--- a/examples/lod_terrain/smooth_voxel_map.rs
+++ b/examples/lod_terrain/smooth_voxel_map.rs
@@ -75,8 +75,8 @@ impl VoxelMap for SmoothVoxelMap {
         Box::new(self.chunks.indexer.chunk_mins_for_extent(&lod0_extent))
     }
 
-    fn chunk_is_generated(&self, minimum: Point3i) -> bool {
-        self.chunks.get_chunk(ChunkKey::new(0, minimum)).is_some()
+    fn chunk_is_generated(&self, minimum: Point3i, lod: u8) -> bool {
+        self.chunks.get_chunk(ChunkKey::new(lod, minimum)).is_some()
     }
 
     fn generate_chunk(&self, minimum: Point3i) -> Option<Array3x1<Self::Voxel>> {
@@ -93,21 +93,21 @@ impl VoxelMap for SmoothVoxelMap {
         } = self.config;
 
         let chunk_shape = Point3i::fill(1 << chunk_exponent);
-
-        generate_noise_chunk3(minimum, chunk_shape, freq, scale, seed, octaves, true)
+        let chunk_extent = Extent3i::from_min_and_shape(minimum, chunk_shape);
+        generate_noise_chunk3(chunk_extent, freq, scale, seed, octaves, true)
     }
 
     fn write_chunk(&mut self, key: ChunkKey3, chunk: Array3x1<Self::Voxel>) {
         self.chunks.write_chunk(key, chunk);
     }
 
-    fn downsample_extent_into_self(&mut self, extent: Extent3i) {
-        self.chunks.downsample_extent_into_self(
-            &PointDownsampler,
-            0,
-            self.chunks.root_lod(),
-            extent,
-        );
+    fn downsample_extent_into_self(&mut self, extent: Extent3i, src_lod: u8, max_lod: u8) {
+        self.chunks
+            .downsample_extent_into_self(&PointDownsampler, src_lod, max_lod, extent);
+    }
+
+    fn remove_chunk(&mut self, key: ChunkKey3) {
+        self.chunks.pop_chunk(key);
     }
 
     fn config(&self) -> &MapConfig {

--- a/examples/lod_terrain/smooth_voxel_map.rs
+++ b/examples/lod_terrain/smooth_voxel_map.rs
@@ -101,9 +101,13 @@ impl VoxelMap for SmoothVoxelMap {
         self.chunks.write_chunk(key, chunk);
     }
 
-    fn downsample_extent(&mut self, extent: Extent3i) {
-        self.chunks
-            .downsample_extent(&PointDownsampler, 0, self.chunks.root_lod(), extent);
+    fn downsample_extent_into_self(&mut self, extent: Extent3i) {
+        self.chunks.downsample_extent_into_self(
+            &PointDownsampler,
+            0,
+            self.chunks.root_lod(),
+            extent,
+        );
     }
 
     fn config(&self) -> &MapConfig {

--- a/examples/lod_terrain/voxel_map.rs
+++ b/examples/lod_terrain/voxel_map.rs
@@ -4,9 +4,22 @@ use building_blocks::{mesh::PosNormMesh, prelude::*};
 use serde::{Deserialize, Serialize};
 
 pub trait VoxelMap: ecs::component::Component {
+    type Voxel: Send;
     type MeshBuffers: Send;
 
     fn generate(pool: &ComputeTaskPool, config: MapConfig) -> Self;
+
+    fn chunk_extent_at_lower_lod(&self, key: ChunkKey3, lod: u8) -> Extent3i;
+
+    fn iter_chunks_for_key(&self, key: ChunkKey3) -> Box<dyn Iterator<Item = Point3i>>;
+
+    fn chunk_is_generated(&self, minimum: Point3i) -> bool;
+
+    fn generate_chunk(&self, minimum: Point3i) -> Option<Array3x1<Self::Voxel>>;
+
+    fn write_chunk(&mut self, key: ChunkKey3, chunk: Array3x1<Self::Voxel>);
+
+    fn downsample_extent(&mut self, extent: Extent3i);
 
     fn config(&self) -> &MapConfig;
 

--- a/examples/lod_terrain/voxel_map.rs
+++ b/examples/lod_terrain/voxel_map.rs
@@ -13,13 +13,15 @@ pub trait VoxelMap: ecs::component::Component {
 
     fn iter_chunks_for_key(&self, key: ChunkKey3) -> Box<dyn Iterator<Item = Point3i>>;
 
-    fn chunk_is_generated(&self, minimum: Point3i) -> bool;
+    fn chunk_is_generated(&self, minimum: Point3i, lod: u8) -> bool;
 
     fn generate_chunk(&self, minimum: Point3i) -> Option<Array3x1<Self::Voxel>>;
 
     fn write_chunk(&mut self, key: ChunkKey3, chunk: Array3x1<Self::Voxel>);
 
-    fn downsample_extent_into_self(&mut self, extent: Extent3i);
+    fn remove_chunk(&mut self, key: ChunkKey3);
+
+    fn downsample_extent_into_self(&mut self, extent: Extent3i, src_lod: u8, max_lod: u8);
 
     fn config(&self) -> &MapConfig;
 

--- a/examples/lod_terrain/voxel_map.rs
+++ b/examples/lod_terrain/voxel_map.rs
@@ -19,7 +19,7 @@ pub trait VoxelMap: ecs::component::Component {
 
     fn write_chunk(&mut self, key: ChunkKey3, chunk: Array3x1<Self::Voxel>);
 
-    fn downsample_extent(&mut self, extent: Extent3i);
+    fn downsample_extent_into_self(&mut self, extent: Extent3i);
 
     fn config(&self) -> &MapConfig;
 

--- a/examples/mesh_showcase/mesh_generator.rs
+++ b/examples/mesh_showcase/mesh_generator.rs
@@ -187,7 +187,9 @@ pub fn mesh_generator_system(
         let chunk_meshes = match choose_shape(state.current_shape_index) {
             Shape::Sdf(sdf) => generate_chunk_meshes_from_sdf(sdf, &pool.0, state.flat_shaded),
             Shape::SdfNoise => generate_chunk_meshes_from_sdf_noise(&pool.0, state.flat_shaded),
-            Shape::HeightMap(hm) => generate_chunk_meshes_from_height_map(hm, &pool.0, state.flat_shaded),
+            Shape::HeightMap(hm) => {
+                generate_chunk_meshes_from_height_map(hm, &pool.0, state.flat_shaded)
+            }
             Shape::Blocky(blocky) => generate_chunk_meshes_from_blocky(blocky, &pool.0),
         };
 
@@ -247,7 +249,11 @@ fn generate_chunk_meshes_from_sdf_noise(
 
     // Normally we'd keep this map around in a resource, but we don't need to for this specific example. We could also use an
     // Array3x1 here instead of a ChunkTree3, but we use chunks for educational purposes.
-    let builder = ChunkTreeBuilder3x1::new(ChunkTreeConfig { chunk_shape: PointN([16; 3]), ambient_value: 99999.0, root_lod: 0 });
+    let builder = ChunkTreeBuilder3x1::new(ChunkTreeConfig {
+        chunk_shape: PointN([16; 3]),
+        ambient_value: 99999.0,
+        root_lod: 0,
+    });
     let mut map = builder.build_with_hash_map_storage();
     for (chunk_min, chunk) in noise_chunks.into_iter() {
         map.write_chunk(ChunkKey::new(0, chunk_min), chunk);
@@ -296,7 +302,7 @@ fn generate_surface_nets_meshes<T: 'static + Clone + Send + Sync + SignedDistanc
 fn generate_chunk_meshes_from_height_map(
     hm: HeightMap,
     pool: &TaskPool,
-    flat_shaded: bool
+    flat_shaded: bool,
 ) -> Vec<Option<PosNormMesh>> {
     let height_map = hm.get_height_map();
     let sample_extent =
@@ -304,7 +310,11 @@ fn generate_chunk_meshes_from_height_map(
 
     // Normally we'd keep this map around in a resource, but we don't need to for this specific example. We could also use an
     // Array3x1 here instead of a ChunkTree3, but we use chunks for educational purposes.
-    let builder = ChunkTreeBuilder2x1::new(ChunkTreeConfig { chunk_shape: PointN([16; 2]), ambient_value: 0.0, root_lod: 0 });
+    let builder = ChunkTreeBuilder2x1::new(ChunkTreeConfig {
+        chunk_shape: PointN([16; 2]),
+        ambient_value: 0.0,
+        root_lod: 0,
+    });
     let mut map = builder.build_with_hash_map_storage();
     copy_extent(&sample_extent, &Func(height_map), &mut map.lod_view_mut(0));
 


### PR DESCRIPTION
After @bonsairobo added the clipmap_events API, I wanted to try to get on-the-fly generation working. This is stuttery and not cleanly implemented, but it's proving the concept. This isn't ready for merging, but it's a starting point from which we can iterate. Shout up with ideas! :)

I think in practice we really need to spread the workload over multiple frames in order to avoid the big stutters when generating a lot of new chunks and downsampling them and meshing the downsampled data all in one frame. Some ideas for approaches:

1. Generate lod0 chunks when the lod0 chunks themselves come into clipmap range, instead of when the higher lod chunk comes into range and then having to generate a large number of lod0 chunks all at once. This may need a separate 'chunk detection' system. I tried to write one last night but it broke the generation so I rolled it back. Downsampling could still happen at the point of needing to downsample for a higher lod mesh when that lod chunk comes into range and triggers an Enter event.
1. Generate chunks _at the lod required_ rather than at lod0 + downsampling. So when an Enter event is triggered at a higher lod, instead of having to generate at lod0 and then downsampling to at least that higher lod if not the root lod, just generate at that higher lod. Then when a lower lod is needed, generate at that lower lod. Maybe at some point downsampling should be done for consistency, or maybe generating at the required lod is better / sufficiently fast?
1. Somehow split downsampling over multiple frames. @bonsairobo has implemented support for this, downsampling between two lods, but I am not sure how to leverage it in terms of doing it between generation and the point at which a mesh is needed. I suppose if using approach 1 - generating the lod0 chunks as they come into range, one could downsample from lod0 to lod1 when all the lod0 chunks have been generated. And from lod1 to lod2 when all the lod1 chunks have been downsampled. Etc.