### PR TITLE
Cgmath type conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ trace = ["building_blocks_storage/tracing"]
 glam = ["building_blocks_core/glam"]
 mint = ["building_blocks_core/mint"]
 nalgebra = ["building_blocks_core/nalgebra"]
+cgmath = ["building_blocks_core/cgmath"]
 
 # Compression backends.
 lz4 = ["building_blocks_storage/lz4"]

--- a/crates/building_blocks_core/Cargo.toml
+++ b/crates/building_blocks_core/Cargo.toml
@@ -28,3 +28,4 @@ mint = { version = "0.5.0", optional = true }
 nalgebra = { version = "0.28", optional = true }
 sdfu = { version = "0.3", optional = true }
 vox-format = { version = "0.1", optional = true }
+cgmath = { version = "0.18", optional = true }

--- a/crates/building_blocks_core/src/point.rs
+++ b/crates/building_blocks_core/src/point.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 pub mod point_traits;
 
+#[cfg(feature = "cgmath")]
+mod cgmath_conversions;
 #[cfg(feature = "glam")]
 mod glam_conversions;
 #[cfg(feature = "mint")]

--- a/crates/building_blocks_core/src/point/cgmath_conversions.rs
+++ b/crates/building_blocks_core/src/point/cgmath_conversions.rs
@@ -4,6 +4,14 @@ use cgmath;
 
 impl From<Point2i> for cgmath::Point2<i32> {
     #[inline]
+    /// Converts to cgmath::Point2<i32> from Point2i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    /// let p : Point2i = PointN([1_i32, 2]);
+    /// let c = cgmath::Point2::<i32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: Point2i) -> Self {
         cgmath::Point2::new(p.x(), p.y())
     }
@@ -11,6 +19,14 @@ impl From<Point2i> for cgmath::Point2<i32> {
 
 impl From<Point2f> for cgmath::Point2<f32> {
     #[inline]
+    /// Converts to cgmath::Point2<f32> from Point2f
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2f};
+    /// let p : Point2f = PointN([1_f32, 2.0]);
+    /// let c = cgmath::Point2::<f32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: Point2f) -> Self {
         cgmath::Point2::new(p.x(), p.y())
     }
@@ -18,6 +34,14 @@ impl From<Point2f> for cgmath::Point2<f32> {
 
 impl From<Point2i> for cgmath::Vector2<i32> {
     #[inline]
+    /// Converts to cgmath::Vector2<i32> from Point2i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    /// let p : Point2i = PointN([1_i32, 2]);
+    /// let c = cgmath::Vector2::<i32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: Point2i) -> Self {
         cgmath::Vector2::new(p.x(), p.y())
     }
@@ -25,6 +49,14 @@ impl From<Point2i> for cgmath::Vector2<i32> {
 
 impl From<Point2f> for cgmath::Vector2<f32> {
     #[inline]
+    /// Converts to cgmath::Vector2<f32> from Point2f
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2f};
+    /// let p : Point2f = PointN([1_f32, 2.0]);
+    /// let c = cgmath::Vector2::<f32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: Point2f) -> Self {
         cgmath::Vector2::new(p.x(), p.y())
     }
@@ -32,6 +64,14 @@ impl From<Point2f> for cgmath::Vector2<f32> {
 
 impl From<cgmath::Point2<i32>> for Point2i {
     #[inline]
+    /// Converts to Point2i from cgmath::Point2<i32>
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    /// let c = cgmath::Point2::<i32>::new(1,2);
+    /// let p = Point2i::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: cgmath::Point2<i32>) -> Self {
         PointN([p.x, p.y])
     }
@@ -39,6 +79,14 @@ impl From<cgmath::Point2<i32>> for Point2i {
 
 impl From<cgmath::Point2<f32>> for Point2f {
     #[inline]
+    /// Converts to Point2f from cgmath::Point2<f32>
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2f};
+    /// let c = cgmath::Point2::<f32>::new(1.0,2.0);
+    /// let p = Point2f::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: cgmath::Point2<f32>) -> Self {
         PointN([p.x, p.y])
     }
@@ -46,6 +94,14 @@ impl From<cgmath::Point2<f32>> for Point2f {
 
 impl From<cgmath::Vector2<i32>> for Point2i {
     #[inline]
+    /// Converts to Point2i from cgmath::Vector2<i32>
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    /// let c = cgmath::Vector2::<i32>::new(1,2);
+    /// let p = Point2i::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: cgmath::Vector2<i32>) -> Self {
         PointN([p.x, p.y])
     }
@@ -53,6 +109,14 @@ impl From<cgmath::Vector2<i32>> for Point2i {
 
 impl From<cgmath::Vector2<f32>> for Point2f {
     #[inline]
+    /// Converts to Point2f from cgmath::Vector2<f32>
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2f};
+    /// let c = cgmath::Vector2::<f32>::new(1.0,2.0);
+    /// let p = Point2f::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// ```
     fn from(p: cgmath::Vector2<f32>) -> Self {
         PointN([p.x, p.y])
     }
@@ -60,6 +124,15 @@ impl From<cgmath::Vector2<f32>> for Point2f {
 
 impl From<Point2i> for cgmath::Point2<f32> {
     #[inline]
+    /// Converts to cgmath::Point2<f32> from Point2i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    ///
+    /// let p : Point2i = PointN([1_i32, 2]);
+    /// let c = cgmath::Point2::<f32>::from(p);
+    /// assert_eq!(c.x , p.x() as f32);
+    /// assert_eq!(c.y , p.y() as f32);
+    /// ```
     fn from(p: Point2i) -> Self {
         cgmath::Point2::new(p.x() as f32, p.y() as f32)
     }
@@ -67,6 +140,14 @@ impl From<Point2i> for cgmath::Point2<f32> {
 
 impl From<Point2i> for cgmath::Vector2<f32> {
     #[inline]
+    /// Converts to cgmath::Vector2<f32> from Point2i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point2i};
+    /// let p : Point2i = PointN([1_i32, 2]);
+    /// let c = cgmath::Vector2::<f32>::from(p);
+    /// assert_eq!(c.x , p.x() as f32);
+    /// assert_eq!(c.y , p.y() as f32);
+    /// ```
     fn from(p: Point2i) -> Self {
         cgmath::Vector2::new(p.x() as f32, p.y() as f32)
     }
@@ -74,24 +155,63 @@ impl From<Point2i> for cgmath::Vector2<f32> {
 
 impl From<Point3i> for cgmath::Point3<i32> {
     #[inline]
+    /// Converts to cgmath::Point3<i32> from Point3i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3i};
+    /// let p : Point3i = PointN([1_i32, 2, 3]);
+    /// let c = cgmath::Point3::<i32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: Point3i) -> Self {
         cgmath::Point3::from(p.0)
     }
 }
+
 impl From<Point3f> for cgmath::Point3<f32> {
     #[inline]
+    /// Converts to cgmath::Point3<f32> from Point3f
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3f};
+    /// let p : Point3f = PointN([1.0_f32, 2.0, 3.0]);
+    /// let c = cgmath::Point3::<f32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: Point3f) -> Self {
         cgmath::Point3::from(p.0)
     }
 }
+
 impl From<Point3i> for cgmath::Vector3<i32> {
     #[inline]
+    /// Converts to cgmath::Vector3<i32> from Point3i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3i};
+    /// let p : Point3i = PointN([1_i32, 2, 3]);
+    /// let c = cgmath::Vector3::<i32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: Point3i) -> Self {
         cgmath::Vector3::from(p.0)
     }
 }
+
 impl From<Point3f> for cgmath::Vector3<f32> {
     #[inline]
+    /// Converts to cgmath::Vector3<f32> from Point3f
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3f};
+    /// let p : Point3f = PointN([1.0_f32, 2.0, 3.0]);
+    /// let c = cgmath::Vector3::<f32>::from(p);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: Point3f) -> Self {
         cgmath::Vector3::from(p.0)
     }
@@ -99,6 +219,15 @@ impl From<Point3f> for cgmath::Vector3<f32> {
 
 impl From<cgmath::Point3<i32>> for Point3i {
     #[inline]
+    /// Converts to Point3i from cgmath::Point3<i32>
+    /// ```
+    /// # use building_blocks_core::Point3i;
+    /// let c = cgmath::Point3::<i32>::new(1,2,3);
+    /// let p = Point3i::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: cgmath::Point3<i32>) -> Self {
         PointN([p.x, p.y, p.z])
     }
@@ -106,6 +235,16 @@ impl From<cgmath::Point3<i32>> for Point3i {
 
 impl From<cgmath::Point3<f32>> for Point3f {
     #[inline]
+    /// Converts to Point3f from cgmath::Point3<f32>
+    /// ```
+    /// # use building_blocks_core::Point3f;
+    ///
+    /// let c = cgmath::Point3::<f32>::new(1.0,2.0,3.0);
+    /// let p = Point3f::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: cgmath::Point3<f32>) -> Self {
         PointN([p.x, p.y, p.z])
     }
@@ -113,6 +252,15 @@ impl From<cgmath::Point3<f32>> for Point3f {
 
 impl From<cgmath::Vector3<i32>> for Point3i {
     #[inline]
+    /// Converts to Point3i from cgmath::Vector3<i32>
+    /// ```
+    /// # use building_blocks_core::Point3i;
+    /// let c = cgmath::Vector3::<i32>::new(1,2,3);
+    /// let p = Point3i::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: cgmath::Vector3<i32>) -> Self {
         PointN([p.x, p.y, p.z])
     }
@@ -120,6 +268,15 @@ impl From<cgmath::Vector3<i32>> for Point3i {
 
 impl From<cgmath::Vector3<f32>> for Point3f {
     #[inline]
+    /// Converts to Point3f from cgmath::Vector3<f32>
+    /// ```
+    /// # use building_blocks_core::Point3f;
+    /// let c = cgmath::Vector3::<f32>::new(1.0,2.0,3.0);
+    /// let p = Point3f::from(c);
+    /// assert_eq!(c.x , p.x());
+    /// assert_eq!(c.y , p.y());
+    /// assert_eq!(c.z , p.z());
+    /// ```
     fn from(p: cgmath::Vector3<f32>) -> Self {
         PointN([p.x, p.y, p.z])
     }
@@ -127,6 +284,15 @@ impl From<cgmath::Vector3<f32>> for Point3f {
 
 impl From<Point3i> for cgmath::Point3<f32> {
     #[inline]
+    /// Converts to cgmath::Point3<f32> from Point3i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3i};
+    /// let p : Point3i = PointN([1_i32, 2, 3]);
+    /// let c = cgmath::Point3::<f32>::from(p);
+    /// assert_eq!(c.x , p.x() as f32);
+    /// assert_eq!(c.y , p.y() as f32);
+    /// assert_eq!(c.z , p.z() as f32);
+    /// ```
     fn from(p: Point3i) -> Self {
         cgmath::Point3::new(p.x() as f32, p.y() as f32, p.z() as f32)
     }
@@ -134,6 +300,15 @@ impl From<Point3i> for cgmath::Point3<f32> {
 
 impl From<Point3i> for cgmath::Vector3<f32> {
     #[inline]
+    /// Converts to cgmath::Vector3<f32> from Point3i
+    /// ```
+    /// # use building_blocks_core::{PointN,Point3i};
+    /// let p : Point3i = PointN([1_i32, 2, 3]);
+    /// let c = cgmath::Vector3::<f32>::from(p);
+    /// assert_eq!(c.x , p.x() as f32);
+    /// assert_eq!(c.y , p.y() as f32);
+    /// assert_eq!(c.z , p.z() as f32);
+    /// ```
     fn from(p: Point3i) -> Self {
         cgmath::Vector3::new(p.x() as f32, p.y() as f32, p.z() as f32)
     }

--- a/crates/building_blocks_core/src/point/cgmath_conversions.rs
+++ b/crates/building_blocks_core/src/point/cgmath_conversions.rs
@@ -1,0 +1,140 @@
+use super::*;
+
+use cgmath;
+
+impl From<Point2i> for cgmath::Point2<i32> {
+    #[inline]
+    fn from(p: Point2i) -> Self {
+        cgmath::Point2::new(p.x(), p.y())
+    }
+}
+
+impl From<Point2f> for cgmath::Point2<f32> {
+    #[inline]
+    fn from(p: Point2f) -> Self {
+        cgmath::Point2::new(p.x(), p.y())
+    }
+}
+
+impl From<Point2i> for cgmath::Vector2<i32> {
+    #[inline]
+    fn from(p: Point2i) -> Self {
+        cgmath::Vector2::new(p.x(), p.y())
+    }
+}
+
+impl From<Point2f> for cgmath::Vector2<f32> {
+    #[inline]
+    fn from(p: Point2f) -> Self {
+        cgmath::Vector2::new(p.x(), p.y())
+    }
+}
+
+impl From<cgmath::Point2<i32>> for Point2i {
+    #[inline]
+    fn from(p: cgmath::Point2<i32>) -> Self {
+        PointN([p.x, p.y])
+    }
+}
+
+impl From<cgmath::Point2<f32>> for Point2f {
+    #[inline]
+    fn from(p: cgmath::Point2<f32>) -> Self {
+        PointN([p.x, p.y])
+    }
+}
+
+impl From<cgmath::Vector2<i32>> for Point2i {
+    #[inline]
+    fn from(p: cgmath::Vector2<i32>) -> Self {
+        PointN([p.x, p.y])
+    }
+}
+
+impl From<cgmath::Vector2<f32>> for Point2f {
+    #[inline]
+    fn from(p: cgmath::Vector2<f32>) -> Self {
+        PointN([p.x, p.y])
+    }
+}
+
+impl From<Point2i> for cgmath::Point2<f32> {
+    #[inline]
+    fn from(p: Point2i) -> Self {
+        cgmath::Point2::new(p.x() as f32, p.y() as f32)
+    }
+}
+
+impl From<Point2i> for cgmath::Vector2<f32> {
+    #[inline]
+    fn from(p: Point2i) -> Self {
+        cgmath::Vector2::new(p.x() as f32, p.y() as f32)
+    }
+}
+
+impl From<Point3i> for cgmath::Point3<i32> {
+    #[inline]
+    fn from(p: Point3i) -> Self {
+        cgmath::Point3::from(p.0)
+    }
+}
+impl From<Point3f> for cgmath::Point3<f32> {
+    #[inline]
+    fn from(p: Point3f) -> Self {
+        cgmath::Point3::from(p.0)
+    }
+}
+impl From<Point3i> for cgmath::Vector3<i32> {
+    #[inline]
+    fn from(p: Point3i) -> Self {
+        cgmath::Vector3::from(p.0)
+    }
+}
+impl From<Point3f> for cgmath::Vector3<f32> {
+    #[inline]
+    fn from(p: Point3f) -> Self {
+        cgmath::Vector3::from(p.0)
+    }
+}
+
+impl From<cgmath::Point3<i32>> for Point3i {
+    #[inline]
+    fn from(p: cgmath::Point3<i32>) -> Self {
+        PointN([p.x, p.y, p.z])
+    }
+}
+
+impl From<cgmath::Point3<f32>> for Point3f {
+    #[inline]
+    fn from(p: cgmath::Point3<f32>) -> Self {
+        PointN([p.x, p.y, p.z])
+    }
+}
+
+impl From<cgmath::Vector3<i32>> for Point3i {
+    #[inline]
+    fn from(p: cgmath::Vector3<i32>) -> Self {
+        PointN([p.x, p.y, p.z])
+    }
+}
+
+impl From<cgmath::Vector3<f32>> for Point3f {
+    #[inline]
+    fn from(p: cgmath::Vector3<f32>) -> Self {
+        PointN([p.x, p.y, p.z])
+    }
+}
+
+impl From<Point3i> for cgmath::Point3<f32> {
+    #[inline]
+    fn from(p: Point3i) -> Self {
+        cgmath::Point3::new(p.x() as f32, p.y() as f32, p.z() as f32)
+    }
+}
+
+impl From<Point3i> for cgmath::Vector3<f32> {
+    #[inline]
+    fn from(p: Point3i) -> Self {
+        cgmath::Vector3::new(p.x() as f32, p.y() as f32, p.z() as f32)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@
 //!
 //! ### Math Type Conversions
 //!
-//! The `PointN` types have conversions to/from [`glam`](https://docs.rs/glam), [`nalgebra`](https://nalgebra.org/), and
-//! [`mint`](https://docs.rs/mint) types by enabling the corresponding feature.
+//! The `PointN` types have conversions to/from [`glam`](https://docs.rs/glam), [`nalgebra`](https://nalgebra.org/),
+//! [`cgmath`](https://docs.rs/cgmath) and [`mint`](https://docs.rs/mint) types by enabling the corresponding feature.
 //!
 //! ### Compression Backends and WASM
 //!


### PR DESCRIPTION

I suspect that the `Point2i` -> `cgmath::Point2<f32>` conversion will be difficult to implement if using full generic conversions like:
```rust
impl<T> From<Point2<T>> for cgmath::Point2<T> {
    #[inline]
    fn from(p: Point2<T>) -> Self {
        cgmath::Point2::new(p.x(), p.y())
    }
}
```
Last time I tried something similar the compiler complained about 'already implemented' or something similar, but I can take a look at it sometimes later this week.  
