### PR TITLE
Generic cgmath conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ features = ["foo", "bar"]
 
 #### Math Type Conversions
 
-The `PointN` types have conversions to/from [`glam`](https://docs.rs/glam), [`nalgebra`](https://nalgebra.org/), and
-[`mint`](https://docs.rs/mint) types by enabling the corresponding feature.
+The `PointN` types have conversions to/from [`glam`](https://docs.rs/glam), [`nalgebra`](https://nalgebra.org/), 
+[`cgmath`](https://docs.rs/cgmath) and [`mint`](https://docs.rs/mint) types by enabling the corresponding feature.
 
 #### Compression Backends and WASM
 

--- a/crates/building_blocks_core/src/point/cgmath_conversions.rs
+++ b/crates/building_blocks_core/src/point/cgmath_conversions.rs
@@ -1,123 +1,80 @@
+//! [`cgmath`](https://docs.rs/cgmath) type conversions.
 use super::*;
 
 use cgmath;
 
-impl From<Point2i> for cgmath::Point2<i32> {
+impl<T: std::marker::Copy> From<Point2<T>> for cgmath::Point2<T> {
     #[inline]
-    /// Converts to cgmath::Point2<i32> from Point2i
+    /// Converts to cgmath::Point2<T> from Point2<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point2i};
+    /// # use building_blocks_core::{PointN,Point2i,Point2f};
     /// let p : Point2i = PointN([1_i32, 2]);
     /// let c = cgmath::Point2::<i32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
-    /// ```
-    fn from(p: Point2i) -> Self {
-        cgmath::Point2::new(p.x(), p.y())
-    }
-}
-
-impl From<Point2f> for cgmath::Point2<f32> {
-    #[inline]
-    /// Converts to cgmath::Point2<f32> from Point2f
-    /// ```
-    /// # use building_blocks_core::{PointN,Point2f};
     /// let p : Point2f = PointN([1_f32, 2.0]);
     /// let c = cgmath::Point2::<f32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// ```
-    fn from(p: Point2f) -> Self {
-        cgmath::Point2::new(p.x(), p.y())
+    fn from(p: Point2<T>) -> Self {
+        cgmath::Point2::from(p.0)
     }
 }
 
-impl From<Point2i> for cgmath::Vector2<i32> {
+impl<T: std::marker::Copy> From<Point2<T>> for cgmath::Vector2<T> {
     #[inline]
-    /// Converts to cgmath::Vector2<i32> from Point2i
+    /// Converts to cgmath::Vector2<T> from Point2<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point2i};
+    /// # use building_blocks_core::{PointN,Point2i,Point2f};
     /// let p : Point2i = PointN([1_i32, 2]);
     /// let c = cgmath::Vector2::<i32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
-    /// ```
-    fn from(p: Point2i) -> Self {
-        cgmath::Vector2::new(p.x(), p.y())
-    }
-}
-
-impl From<Point2f> for cgmath::Vector2<f32> {
-    #[inline]
-    /// Converts to cgmath::Vector2<f32> from Point2f
-    /// ```
-    /// # use building_blocks_core::{PointN,Point2f};
     /// let p : Point2f = PointN([1_f32, 2.0]);
     /// let c = cgmath::Vector2::<f32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// ```
-    fn from(p: Point2f) -> Self {
-        cgmath::Vector2::new(p.x(), p.y())
+    fn from(p: Point2<T>) -> Self {
+        cgmath::Vector2::from(p.0)
     }
 }
 
-impl From<cgmath::Point2<i32>> for Point2i {
+impl<T> From<cgmath::Point2<T>> for Point2<T> {
     #[inline]
-    /// Converts to Point2i from cgmath::Point2<i32>
+    /// Converts to Point2<T> from cgmath::Point2<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point2i};
+    /// # use building_blocks_core::{PointN,Point2i,Point2f};
     /// let c = cgmath::Point2::<i32>::new(1,2);
     /// let p = Point2i::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
-    /// ```
-    fn from(p: cgmath::Point2<i32>) -> Self {
-        PointN([p.x, p.y])
-    }
-}
-
-impl From<cgmath::Point2<f32>> for Point2f {
-    #[inline]
-    /// Converts to Point2f from cgmath::Point2<f32>
-    /// ```
-    /// # use building_blocks_core::{PointN,Point2f};
     /// let c = cgmath::Point2::<f32>::new(1.0,2.0);
     /// let p = Point2f::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// ```
-    fn from(p: cgmath::Point2<f32>) -> Self {
+    fn from(p: cgmath::Point2<T>) -> Self {
         PointN([p.x, p.y])
     }
 }
 
-impl From<cgmath::Vector2<i32>> for Point2i {
+impl<T> From<cgmath::Vector2<T>> for Point2<T> {
     #[inline]
-    /// Converts to Point2i from cgmath::Vector2<i32>
+    /// Converts to Point2<T> from cgmath::Vector2<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point2i};
+    /// # use building_blocks_core::{PointN,Point2i,Point2f};
     /// let c = cgmath::Vector2::<i32>::new(1,2);
     /// let p = Point2i::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
-    /// ```
-    fn from(p: cgmath::Vector2<i32>) -> Self {
-        PointN([p.x, p.y])
-    }
-}
-
-impl From<cgmath::Vector2<f32>> for Point2f {
-    #[inline]
-    /// Converts to Point2f from cgmath::Vector2<f32>
-    /// ```
-    /// # use building_blocks_core::{PointN,Point2f};
     /// let c = cgmath::Vector2::<f32>::new(1.0,2.0);
     /// let p = Point2f::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// ```
-    fn from(p: cgmath::Vector2<f32>) -> Self {
+    fn from(p: cgmath::Vector2<T>) -> Self {
         PointN([p.x, p.y])
     }
 }
@@ -153,131 +110,86 @@ impl From<Point2i> for cgmath::Vector2<f32> {
     }
 }
 
-impl From<Point3i> for cgmath::Point3<i32> {
+impl<T: std::marker::Copy> From<Point3<T>> for cgmath::Point3<T> {
     #[inline]
-    /// Converts to cgmath::Point3<i32> from Point3i
+    /// Converts to cgmath::Point3<T> from Point3<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point3i};
+    /// # use building_blocks_core::{PointN,Point3i,Point3f};
     /// let p : Point3i = PointN([1_i32, 2, 3]);
-    /// let c = cgmath::Point3::<i32>::from(p);
+    /// let c = cgmath::Vector3::<i32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
-    /// ```
-    fn from(p: Point3i) -> Self {
-        cgmath::Point3::from(p.0)
-    }
-}
-
-impl From<Point3f> for cgmath::Point3<f32> {
-    #[inline]
-    /// Converts to cgmath::Point3<f32> from Point3f
-    /// ```
-    /// # use building_blocks_core::{PointN,Point3f};
     /// let p : Point3f = PointN([1.0_f32, 2.0, 3.0]);
     /// let c = cgmath::Point3::<f32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
-    /// ```
-    fn from(p: Point3f) -> Self {
-        cgmath::Point3::from(p.0)
-    }
-}
-
-impl From<Point3i> for cgmath::Vector3<i32> {
-    #[inline]
-    /// Converts to cgmath::Vector3<i32> from Point3i
-    /// ```
-    /// # use building_blocks_core::{PointN,Point3i};
     /// let p : Point3i = PointN([1_i32, 2, 3]);
     /// let c = cgmath::Vector3::<i32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
     /// ```
-    fn from(p: Point3i) -> Self {
-        cgmath::Vector3::from(p.0)
+    fn from(p: Point3<T>) -> Self {
+        cgmath::Point3::from(p.0)
     }
 }
 
-impl From<Point3f> for cgmath::Vector3<f32> {
+impl<T: std::marker::Copy> From<Point3<T>> for cgmath::Vector3<T> {
     #[inline]
-    /// Converts to cgmath::Vector3<f32> from Point3f
+    /// Converts to cgmath::Vector3<T> from Point3<T>
     /// ```
-    /// # use building_blocks_core::{PointN,Point3f};
-    /// let p : Point3f = PointN([1.0_f32, 2.0, 3.0]);
-    /// let c = cgmath::Vector3::<f32>::from(p);
+    /// # use building_blocks_core::{PointN,Point3i,Point3f};
+    /// let p : Point3i = PointN([1_i32, 2, 3]);
+    /// let c = cgmath::Vector3::<i32>::from(p);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
     /// ```
-    fn from(p: Point3f) -> Self {
+    fn from(p: Point3<T>) -> Self {
         cgmath::Vector3::from(p.0)
     }
 }
 
-impl From<cgmath::Point3<i32>> for Point3i {
+impl<T> From<cgmath::Point3<T>> for Point3<T> {
     #[inline]
-    /// Converts to Point3i from cgmath::Point3<i32>
+    /// Converts to Point3<T> from cgmath::Point3<T>
     /// ```
-    /// # use building_blocks_core::Point3i;
+    /// # use building_blocks_core::{Point3i,Point3f};
     /// let c = cgmath::Point3::<i32>::new(1,2,3);
     /// let p = Point3i::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
-    /// ```
-    fn from(p: cgmath::Point3<i32>) -> Self {
-        PointN([p.x, p.y, p.z])
-    }
-}
-
-impl From<cgmath::Point3<f32>> for Point3f {
-    #[inline]
-    /// Converts to Point3f from cgmath::Point3<f32>
-    /// ```
-    /// # use building_blocks_core::Point3f;
-    ///
     /// let c = cgmath::Point3::<f32>::new(1.0,2.0,3.0);
     /// let p = Point3f::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
     /// ```
-    fn from(p: cgmath::Point3<f32>) -> Self {
+    fn from(p: cgmath::Point3<T>) -> Self {
         PointN([p.x, p.y, p.z])
     }
 }
 
-impl From<cgmath::Vector3<i32>> for Point3i {
+impl<T> From<cgmath::Vector3<T>> for Point3<T> {
     #[inline]
-    /// Converts to Point3i from cgmath::Vector3<i32>
+    /// Converts to Point3<T> from cgmath::Vector3<T>
     /// ```
-    /// # use building_blocks_core::Point3i;
+    /// # use building_blocks_core::{Point3i,Point3f};
     /// let c = cgmath::Vector3::<i32>::new(1,2,3);
     /// let p = Point3i::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
-    /// ```
-    fn from(p: cgmath::Vector3<i32>) -> Self {
-        PointN([p.x, p.y, p.z])
-    }
-}
-
-impl From<cgmath::Vector3<f32>> for Point3f {
-    #[inline]
-    /// Converts to Point3f from cgmath::Vector3<f32>
-    /// ```
-    /// # use building_blocks_core::Point3f;
     /// let c = cgmath::Vector3::<f32>::new(1.0,2.0,3.0);
     /// let p = Point3f::from(c);
     /// assert_eq!(c.x , p.x());
     /// assert_eq!(c.y , p.y());
     /// assert_eq!(c.z , p.z());
     /// ```
-    fn from(p: cgmath::Vector3<f32>) -> Self {
+    fn from(p: cgmath::Vector3<T>) -> Self {
         PointN([p.x, p.y, p.z])
     }
 }


### PR DESCRIPTION
Made the cgmath type conversions more generic. 
Tested on stable and nightly.

I suspected that the specific conversions i32->f32 would 'collide' with the generic ones. But Rust handles that just fine.
 
Since `cgmath_conversions.rs`  is just a copy of `nalgebra_conversions.rs` I figure I could backport the changes to nalgebra (if you like.). 
