### PR TITLE
Reduce risk of version mismatch by making all sub-crates use …

### DIFF
--- a/crates/building_blocks_core/src/lib.rs
+++ b/crates/building_blocks_core/src/lib.rs
@@ -25,6 +25,7 @@ pub use sphere::*;
 
 pub use bytemuck;
 pub use num;
+pub use itertools;
 
 #[doc(hidden)]
 pub mod prelude {

--- a/crates/building_blocks_search/Cargo.toml
+++ b/crates/building_blocks_search/Cargo.toml
@@ -19,7 +19,6 @@ ncollide = ["nalgebra", "ncollide3d", "building_blocks_core/nalgebra"]
 
 [dependencies]
 indexmap = "1.5"
-itertools = "0.10"
 pathfinding = "2.1"
 
 # Optional, feature-gated

--- a/crates/building_blocks_search/src/pathfinding.rs
+++ b/crates/building_blocks_search/src/pathfinding.rs
@@ -1,4 +1,4 @@
-use building_blocks_core::{num::Zero, point_traits::Point, prelude::*};
+use building_blocks_core::{num::Zero, point_traits::Point, itertools, prelude::*};
 
 use core::cmp::Ordering;
 use core::hash::Hash;

--- a/crates/building_blocks_storage/Cargo.toml
+++ b/crates/building_blocks_storage/Cargo.toml
@@ -20,8 +20,6 @@ bytemuck = "1.7"
 either = "1.6"
 float-ord = "0.3"
 futures = "0.3"
-itertools = "0.10"
-num = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 slab = "0.4"
 thread_local = "1.1"

--- a/crates/building_blocks_storage/src/array/coords.rs
+++ b/crates/building_blocks_storage/src/array/coords.rs
@@ -1,7 +1,6 @@
+use building_blocks_core::num::Zero;
 use building_blocks_core::prelude::{ConstZero, PointN};
-
 use core::ops::{Add, AddAssign, Deref, Mul, Sub, SubAssign};
-use num::Zero;
 
 /// Map-local coordinates.
 ///


### PR DESCRIPTION
… re-exports of "itertools" and "num" from building_block_core.